### PR TITLE
373-v1120---importing-highlighting-config-is-broken: fixed

### DIFF
--- a/src/LogExpert/Classes/PaintHelper.cs
+++ b/src/LogExpert/Classes/PaintHelper.cs
@@ -44,7 +44,7 @@ namespace LogExpert.Classes
             ILogLine line = logPaintCtx.GetLogLine(rowIndex);
             if (line != null)
             {
-                HilightEntry entry = logPaintCtx.FindHighlightEntry(line, true);
+                HighlightEntry entry = logPaintCtx.FindHighlightEntry(line, true);
                 e.Graphics.SetClip(e.CellBounds);
                 if ((e.State & DataGridViewElementStates.Selected) == DataGridViewElementStates.Selected)
                 {
@@ -290,12 +290,12 @@ namespace LogExpert.Classes
 
         #region Private Methods
 
-        private static void PaintCell(ILogPaintContext logPaintCtx, DataGridViewCellPaintingEventArgs e, BufferedDataGridView gridView, bool noBackgroundFill, HilightEntry groundEntry)
+        private static void PaintCell(ILogPaintContext logPaintCtx, DataGridViewCellPaintingEventArgs e, BufferedDataGridView gridView, bool noBackgroundFill, HighlightEntry groundEntry)
         {
             PaintHighlightedCell(logPaintCtx, e, gridView, noBackgroundFill, groundEntry);
         }
 
-        private static void PaintHighlightedCell(ILogPaintContext logPaintCtx, DataGridViewCellPaintingEventArgs e, BufferedDataGridView gridView, bool noBackgroundFill, HilightEntry groundEntry)
+        private static void PaintHighlightedCell(ILogPaintContext logPaintCtx, DataGridViewCellPaintingEventArgs e, BufferedDataGridView gridView, bool noBackgroundFill, HighlightEntry groundEntry)
         {
             object value = e.Value ?? string.Empty;
 
@@ -314,7 +314,7 @@ namespace LogExpert.Classes
                     hme.StartPos = 0;
                     hme.Length = column.FullValue.Length;
 
-                    var he = new HilightEntry
+                    var he = new HighlightEntry
                     {
                         SearchText = column.FullValue,
                         ForegroundColor = groundEntry?.ForegroundColor ?? ColorMode.ForeColor,
@@ -427,7 +427,7 @@ namespace LogExpert.Classes
         private static IList<HilightMatchEntry> MergeHighlightMatchEntries(IList<HilightMatchEntry> matchList, HilightMatchEntry groundEntry)
         {
             // Fill an area with lenth of whole text with a default hilight entry
-            HilightEntry[] entryArray = new HilightEntry[groundEntry.Length];
+            HighlightEntry[] entryArray = new HighlightEntry[groundEntry.Length];
             for (int i = 0; i < entryArray.Length; ++i)
             {
                 entryArray[i] = groundEntry.HilightEntry;
@@ -455,7 +455,7 @@ namespace LogExpert.Classes
             IList<HilightMatchEntry> mergedList = new List<HilightMatchEntry>();
             if (entryArray.Length > 0)
             {
-                HilightEntry currentEntry = entryArray[0];
+                HighlightEntry currentEntry = entryArray[0];
                 int lastStartPos = 0;
                 int pos = 0;
                 for (; pos < entryArray.Length; ++pos)

--- a/src/LogExpert/Config/ConfigManager.cs
+++ b/src/LogExpert/Config/ConfigManager.cs
@@ -89,6 +89,11 @@ namespace LogExpert.Config
             Instance.Save(fileInfo, Settings);
         }
 
+        public static void Export(FileInfo fileInfo, SettingsFlags flags)
+        {
+            Instance.Save(fileInfo, Settings, flags);
+        }
+
         public static void Import(FileInfo fileInfo, ExportImportFlags flags)
         {
             Instance._settings = Instance.Import(Instance._settings, fileInfo, flags);
@@ -288,13 +293,32 @@ namespace LogExpert.Config
             SaveAsJSON(fileInfo, settings);
         }
 
-        private void SaveAsJSON(FileInfo fileInfo, Settings settings)
+        private void Save(FileInfo fileInfo, Settings settings, SettingsFlags flags)
+        {
+            switch (flags)
+            {
+                case SettingsFlags.HighlightSettings:
+                    SaveHighlightgroupsAsJSON(fileInfo, settings.Preferences.HighlightGroupList);
+                    break;
+            }
+
+            OnConfigChanged(flags);
+        }
+
+        private static void SaveAsJSON(FileInfo fileInfo, Settings settings)
         {
             settings.versionBuild = Assembly.GetExecutingAssembly().GetName().Version.Build;
 
             using StreamWriter sw = new(fileInfo.Create());
             JsonSerializer serializer = new();
             serializer.Serialize(sw, settings);
+        }
+
+        private static void SaveHighlightgroupsAsJSON(FileInfo fileInfo, List<HighlightGroup> groups)
+        {
+            using StreamWriter sw = new(fileInfo.Create());
+            JsonSerializer serializer = new();
+            serializer.Serialize(sw, groups);
         }
 
         private List<HighlightGroup> Import(List<HighlightGroup> currentGroups, FileInfo fileInfo, ExportImportFlags flags)

--- a/src/LogExpert/Controls/LogTabWindow/LogTabWindow.cs
+++ b/src/LogExpert/Controls/LogTabWindow/LogTabWindow.cs
@@ -89,7 +89,7 @@ namespace LogExpert.Controls.LogTabWindow
             Load += OnLogTabWindowLoad;
 
             ConfigManager.Instance.ConfigChanged += OnConfigChanged;
-            HilightGroupList = ConfigManager.Settings.hilightGroupList;
+            HighlightGroupList = ConfigManager.Settings.Preferences.HighlightGroupList;
 
             Rectangle led = new(0, 0, 8, 2);
 
@@ -297,7 +297,7 @@ namespace LogExpert.Controls.LogTabWindow
 
         public Preferences Preferences => ConfigManager.Settings.Preferences;
 
-        public List<HilightGroup> HilightGroupList { get; private set; } = [];
+        public List<HighlightGroup> HighlightGroupList { get; private set; } = [];
 
         //public Settings Settings
         //{
@@ -312,11 +312,11 @@ namespace LogExpert.Controls.LogTabWindow
 
         #region Internals
 
-        internal HilightGroup FindHighlightGroup(string groupName)
+        internal HighlightGroup FindHighlightGroup(string groupName)
         {
-            lock (HilightGroupList)
+            lock (HighlightGroupList)
             {
-                foreach (HilightGroup group in HilightGroupList)
+                foreach (HighlightGroup group in HighlightGroupList)
                 {
                     if (group.GroupName.Equals(groupName))
                     {

--- a/src/LogExpert/Controls/LogTabWindow/LogTabWindowEventHandlers.cs
+++ b/src/LogExpert/Controls/LogTabWindow/LogTabWindowEventHandlers.cs
@@ -481,7 +481,7 @@ namespace LogExpert.Controls.LogTabWindow
         private void OnLogWindowCurrentHighlightGroupChanged(object sender, CurrentHighlightGroupChangedEventArgs e)
         {
             OnHighlightSettingsChanged();
-            ConfigManager.Settings.hilightGroupList = HilightGroupList;
+            ConfigManager.Settings.Preferences.HighlightGroupList = HighlightGroupList;
             ConfigManager.Save(SettingsFlags.HighlightSettings);
         }
 

--- a/src/LogExpert/Controls/LogTabWindow/LogTabWindowPrivate.cs
+++ b/src/LogExpert/Controls/LogTabWindow/LogTabWindowPrivate.cs
@@ -341,7 +341,7 @@ namespace LogExpert.Controls.LogTabWindow
                 KeywordActionList = PluginRegistry.PluginRegistry.Instance.RegisteredKeywordActions,
                 Owner = this,
                 TopMost = TopMost,
-                HighlightGroupList = HilightGroupList,
+                HighlightGroupList = HighlightGroupList,
                 PreSelectedGroupName = groupsComboBoxHighlightGroups.Text
             };
 
@@ -349,9 +349,9 @@ namespace LogExpert.Controls.LogTabWindow
 
             if (res == DialogResult.OK)
             {
-                HilightGroupList = dlg.HighlightGroupList;
+                HighlightGroupList = dlg.HighlightGroupList;
                 FillHighlightComboBox();
-                ConfigManager.Settings.hilightGroupList = HilightGroupList;
+                ConfigManager.Settings.Preferences.HighlightGroupList = HighlightGroupList;
                 ConfigManager.Save(SettingsFlags.HighlightSettings);
                 OnHighlightSettingsChanged();
             }
@@ -361,7 +361,7 @@ namespace LogExpert.Controls.LogTabWindow
         {
             string currentGroupName = groupsComboBoxHighlightGroups.Text;
             groupsComboBoxHighlightGroups.Items.Clear();
-            foreach (HilightGroup group in HilightGroupList)
+            foreach (HighlightGroup group in HighlightGroupList)
             {
                 groupsComboBoxHighlightGroups.Items.Add(group.GroupName);
                 if (group.GroupName.Equals(currentGroupName))
@@ -956,7 +956,7 @@ namespace LogExpert.Controls.LogTabWindow
 
             _bookmarkWindow.PreferencesChanged(ConfigManager.Settings.Preferences, false, flags);
 
-            HilightGroupList = ConfigManager.Settings.hilightGroupList;
+            HighlightGroupList = ConfigManager.Settings.Preferences.HighlightGroupList;
             if ((flags & SettingsFlags.HighlightSettings) == SettingsFlags.HighlightSettings)
             {
                 OnHighlightSettingsChanged();

--- a/src/LogExpert/Controls/LogTabWindow/LogTabWindowPublic.cs
+++ b/src/LogExpert/Controls/LogTabWindow/LogTabWindowPublic.cs
@@ -259,7 +259,7 @@ namespace LogExpert.Controls.LogTabWindow
             return null;
         }
 
-        public HilightGroup FindHighlightGroupByFileMask(string fileName)
+        public HighlightGroup FindHighlightGroupByFileMask(string fileName)
         {
             foreach (HighlightMaskEntry entry in ConfigManager.Settings.Preferences.highlightMaskList)
             {
@@ -269,7 +269,7 @@ namespace LogExpert.Controls.LogTabWindow
                     {
                         if (Regex.IsMatch(fileName, entry.mask))
                         {
-                            HilightGroup group = FindHighlightGroup(entry.highlightGroupName);
+                            HighlightGroup group = FindHighlightGroup(entry.highlightGroupName);
                             return group;
                         }
                     }
@@ -333,9 +333,9 @@ namespace LogExpert.Controls.LogTabWindow
             }
         }
 
-        public void NotifySettingsChanged(object cookie, SettingsFlags flags)
+        public void NotifySettingsChanged(object sender, SettingsFlags flags)
         {
-            if (cookie != this)
+            if (sender != this)
             {
                 NotifyWindowsForChangedPrefs(flags);
             }

--- a/src/LogExpert/Controls/LogWindow/LogWindow.cs
+++ b/src/LogExpert/Controls/LogWindow/LogWindow.cs
@@ -92,7 +92,7 @@ namespace LogExpert.Controls.LogWindow
         private ILogLineColumnizer _currentColumnizer;
 
         //List<HilightEntry> currentHilightEntryList = new List<HilightEntry>();
-        private HilightGroup _currentHighlightGroup = new();
+        private HighlightGroup _currentHighlightGroup = new();
 
         private SearchParams _currentSearchParams;
 
@@ -131,7 +131,7 @@ namespace LogExpert.Controls.LogWindow
         private bool _shouldCancel;
         private bool _shouldTimestampDisplaySyncingCancel;
         private bool _showAdvanced;
-        private List<HilightEntry> _tempHighlightEntryList = [];
+        private List<HighlightEntry> _tempHighlightEntryList = [];
         private int _timeShiftSyncLine = 0;
 
         private bool _waitingForClose;

--- a/src/LogExpert/Controls/LogWindow/LogWindowEventHandlers.cs
+++ b/src/LogExpert/Controls/LogWindow/LogWindowEventHandlers.cs
@@ -382,7 +382,7 @@ namespace LogExpert.Controls.LogWindow
 
             if (line != null)
             {
-                HilightEntry entry = FindFirstNoWordMatchHilightEntry(line);
+                HighlightEntry entry = FindFirstNoWordMatchHilightEntry(line);
                 e.Graphics.SetClip(e.CellBounds);
                 if ((e.State & DataGridViewElementStates.Selected) == DataGridViewElementStates.Selected)
                 {
@@ -1180,7 +1180,7 @@ namespace LogExpert.Controls.LogWindow
         {
             if (dataGridView.EditingControl is DataGridViewTextBoxEditingControl ctl)
             {
-                var he = new HilightEntry()
+                var he = new HighlightEntry()
                 {
                     SearchText = ctl.SelectedText,
                     ForegroundColor = Color.Red,
@@ -1209,7 +1209,7 @@ namespace LogExpert.Controls.LogWindow
         {
             if (dataGridView.EditingControl is DataGridViewTextBoxEditingControl ctl)
             {
-                HilightEntry he = new()
+                HighlightEntry he = new()
                 {
                     SearchText = ctl.SelectedText,
                     ForegroundColor = Color.Red,
@@ -1257,7 +1257,7 @@ namespace LogExpert.Controls.LogWindow
             {
                 lock (_currentHighlightGroupLock)
                 {
-                    _currentHighlightGroup.HilightEntryList.AddRange(_tempHighlightEntryList);
+                    _currentHighlightGroup.HighlightEntryList.AddRange(_tempHighlightEntryList);
                     RemoveTempHighlights();
                     OnCurrentHighlightListChanged();
                 }

--- a/src/LogExpert/Controls/LogWindow/LogWindowPrivate.cs
+++ b/src/LogExpert/Controls/LogWindow/LogWindowPrivate.cs
@@ -812,7 +812,7 @@ namespace LogExpert.Controls.LogWindow
                     //pipeFx.BeginInvoke(i, null, null);
                     ProcessFilterPipes(i);
 
-                    IList<HilightEntry> matchingList = FindMatchingHilightEntries(line);
+                    IList<HighlightEntry> matchingList = FindMatchingHilightEntries(line);
                     LaunchHighlightPlugins(matchingList, i);
                     GetHilightActions(matchingList, out suppressLed, out stopTail, out setBookmark, out bookmarkComment);
                     if (setBookmark)
@@ -860,7 +860,7 @@ namespace LogExpert.Controls.LogWindow
                     ILogLine line = _logFileReader.GetLogLine(i);
                     if (line != null)
                     {
-                        IList<HilightEntry> matchingList = FindMatchingHilightEntries(line);
+                        IList<HighlightEntry> matchingList = FindMatchingHilightEntries(line);
                         LaunchHighlightPlugins(matchingList, i);
                         GetHilightActions(matchingList, out suppressLed, out stopTail, out setBookmark,
                             out bookmarkComment);
@@ -895,14 +895,14 @@ namespace LogExpert.Controls.LogWindow
             }
         }
 
-        private void LaunchHighlightPlugins(IList<HilightEntry> matchingList, int lineNum)
+        private void LaunchHighlightPlugins(IList<HighlightEntry> matchingList, int lineNum)
         {
             LogExpertCallback callback = new(this)
             {
                 LineNum = lineNum
             };
 
-            foreach (HilightEntry entry in matchingList)
+            foreach (HighlightEntry entry in matchingList)
             {
                 if (entry.IsActionEntry && entry.ActionEntry.PluginName != null)
                 {
@@ -1119,14 +1119,14 @@ namespace LogExpert.Controls.LogWindow
         }
 
         private void PaintCell(DataGridViewCellPaintingEventArgs e, BufferedDataGridView gridView, bool noBackgroundFill,
-            HilightEntry groundEntry)
+            HighlightEntry groundEntry)
         {
             PaintHighlightedCell(e, gridView, noBackgroundFill, groundEntry);
         }
 
         private void PaintHighlightedCell(DataGridViewCellPaintingEventArgs e, BufferedDataGridView gridView,
             bool noBackgroundFill,
-            HilightEntry groundEntry)
+            HighlightEntry groundEntry)
         {
             var column = e.Value as IColumn;
 
@@ -1139,7 +1139,7 @@ namespace LogExpert.Controls.LogWindow
                 matchList.RemoveAt(50);
             }
 
-            var he = new HilightEntry
+            var he = new HighlightEntry
             {
                 SearchText = column.DisplayValue,
                 ForegroundColor = groundEntry?.ForegroundColor ?? Color.FromKnownColor(KnownColor.Black),
@@ -1244,7 +1244,7 @@ namespace LogExpert.Controls.LogWindow
             HilightMatchEntry groundEntry)
         {
             // Fill an area with lenth of whole text with a default hilight entry
-            HilightEntry[] entryArray = new HilightEntry[groundEntry.Length];
+            HighlightEntry[] entryArray = new HighlightEntry[groundEntry.Length];
             for (int i = 0; i < entryArray.Length; ++i)
             {
                 entryArray[i] = groundEntry.HilightEntry;
@@ -1273,7 +1273,7 @@ namespace LogExpert.Controls.LogWindow
 
             if (entryArray.Length > 0)
             {
-                HilightEntry currentEntry = entryArray[0];
+                HighlightEntry currentEntry = entryArray[0];
                 int lastStartPos = 0;
                 int pos = 0;
 
@@ -1310,17 +1310,17 @@ namespace LogExpert.Controls.LogWindow
         /// <summary>
         /// Returns the first HilightEntry that matches the given line
         /// </summary>
-        private HilightEntry FindHilightEntry(ITextValue line)
+        private HighlightEntry FindHilightEntry(ITextValue line)
         {
             return FindHighlightEntry(line, false);
         }
 
-        private HilightEntry FindFirstNoWordMatchHilightEntry(ITextValue line)
+        private HighlightEntry FindFirstNoWordMatchHilightEntry(ITextValue line)
         {
             return FindHighlightEntry(line, true);
         }
 
-        private bool CheckHighlightEntryMatch(HilightEntry entry, ITextValue column)
+        private bool CheckHighlightEntryMatch(HighlightEntry entry, ITextValue column)
         {
             if (entry.IsRegEx)
             {
@@ -1354,14 +1354,14 @@ namespace LogExpert.Controls.LogWindow
         /// <summary>
         /// Returns all HilightEntry entries which matches the given line
         /// </summary>
-        private IList<HilightEntry> FindMatchingHilightEntries(ITextValue line)
+        private IList<HighlightEntry> FindMatchingHilightEntries(ITextValue line)
         {
-            IList<HilightEntry> resultList = [];
+            IList<HighlightEntry> resultList = [];
             if (line != null)
             {
                 lock (_currentHighlightGroupLock)
                 {
-                    foreach (HilightEntry entry in _currentHighlightGroup.HilightEntryList)
+                    foreach (HighlightEntry entry in _currentHighlightGroup.HighlightEntryList)
                     {
                         if (CheckHighlightEntryMatch(entry, line))
                         {
@@ -1374,9 +1374,9 @@ namespace LogExpert.Controls.LogWindow
             return resultList;
         }
 
-        private void GetHighlightEntryMatches(ITextValue line, IList<HilightEntry> hilightEntryList, IList<HilightMatchEntry> resultList)
+        private void GetHighlightEntryMatches(ITextValue line, IList<HighlightEntry> hilightEntryList, IList<HilightMatchEntry> resultList)
         {
-            foreach (HilightEntry entry in hilightEntryList)
+            foreach (HighlightEntry entry in hilightEntryList)
             {
                 if (entry.IsWordMatch)
                 {
@@ -1404,13 +1404,13 @@ namespace LogExpert.Controls.LogWindow
             }
         }
 
-        private void GetHilightActions(IList<HilightEntry> matchingList, out bool noLed, out bool stopTail,
+        private void GetHilightActions(IList<HighlightEntry> matchingList, out bool noLed, out bool stopTail,
             out bool setBookmark, out string bookmarkComment)
         {
             noLed = stopTail = setBookmark = false;
             bookmarkComment = string.Empty;
 
-            foreach (HilightEntry entry in matchingList)
+            foreach (HighlightEntry entry in matchingList)
             {
                 if (entry.IsLedSwitch)
                 {
@@ -1797,7 +1797,7 @@ namespace LogExpert.Controls.LogWindow
                 ILogLine line = _logFileReader.GetLogLine(lineNum);
                 if (line != null)
                 {
-                    HilightEntry entry = FindHilightEntry(line);
+                    HighlightEntry entry = FindHilightEntry(line);
                     if (entry != null)
                     {
                         SelectLine(lineNum, false, true);
@@ -1816,7 +1816,7 @@ namespace LogExpert.Controls.LogWindow
                 ILogLine line = _logFileReader.GetLogLine(lineNum);
                 if (line != null)
                 {
-                    HilightEntry entry = FindHilightEntry(line);
+                    HighlightEntry entry = FindHilightEntry(line);
                     if (entry != null)
                     {
                         SelectLine(lineNum, false, true);
@@ -3595,7 +3595,7 @@ namespace LogExpert.Controls.LogWindow
 
         private void SetDefaultHighlightGroup()
         {
-            HilightGroup group = _parentLogTabWin.FindHighlightGroupByFileMask(FileName);
+            HighlightGroup group = _parentLogTabWin.FindHighlightGroupByFileMask(FileName);
             if (group != null)
             {
                 SetCurrentHighlightGroup(group.GroupName);
@@ -3676,7 +3676,7 @@ namespace LogExpert.Controls.LogWindow
 
         private void AddSearchHitHighlightEntry(SearchParams para)
         {
-            HilightEntry he = new()
+            HighlightEntry he = new()
             {
                 SearchText = para.searchText,
                 ForegroundColor = Color.Red,
@@ -3704,8 +3704,8 @@ namespace LogExpert.Controls.LogWindow
         {
             lock (_tempHighlightEntryListLock)
             {
-                List<HilightEntry> newList = [];
-                foreach (HilightEntry he in _tempHighlightEntryList)
+                List<HighlightEntry> newList = [];
+                foreach (HighlightEntry he in _tempHighlightEntryList)
                 {
                     if (!he.IsSearchHit)
                     {

--- a/src/LogExpert/Controls/LogWindow/LogWindowsPublic.cs
+++ b/src/LogExpert/Controls/LogWindow/LogWindowsPublic.cs
@@ -412,7 +412,7 @@ namespace LogExpert.Controls.LogWindow
 
             if (line != null)
             {
-                HilightEntry entry = FindFirstNoWordMatchHilightEntry(line);
+                HighlightEntry entry = FindFirstNoWordMatchHilightEntry(line);
                 e.Graphics.SetClip(e.CellBounds);
 
                 if ((e.State & DataGridViewElementStates.Selected) == DataGridViewElementStates.Selected)
@@ -511,12 +511,12 @@ namespace LogExpert.Controls.LogWindow
         /// <param name="line"></param>
         /// <param name="noWordMatches"></param>
         /// <returns></returns>
-        public HilightEntry FindHighlightEntry(ITextValue line, bool noWordMatches)
+        public HighlightEntry FindHighlightEntry(ITextValue line, bool noWordMatches)
         {
             // first check the temp entries
             lock (_tempHighlightEntryListLock)
             {
-                foreach (HilightEntry entry in _tempHighlightEntryList)
+                foreach (HighlightEntry entry in _tempHighlightEntryList)
                 {
                     if (noWordMatches && entry.IsWordMatch)
                     {
@@ -531,7 +531,7 @@ namespace LogExpert.Controls.LogWindow
 
             lock (_currentHighlightGroupLock)
             {
-                foreach (HilightEntry entry in _currentHighlightGroup.HilightEntryList)
+                foreach (HighlightEntry entry in _currentHighlightGroup.HighlightEntryList)
                 {
                     if (noWordMatches && entry.IsWordMatch)
                     {
@@ -553,7 +553,7 @@ namespace LogExpert.Controls.LogWindow
             {
                 lock (_currentHighlightGroupLock)
                 {
-                    GetHighlightEntryMatches(column, _currentHighlightGroup.HilightEntryList, resultList);
+                    GetHighlightEntryMatches(column, _currentHighlightGroup.HighlightEntryList, resultList);
                 }
                 lock (_tempHighlightEntryList)
                 {
@@ -1754,13 +1754,13 @@ namespace LogExpert.Controls.LogWindow
                 _currentHighlightGroup = _parentLogTabWin.FindHighlightGroup(groupName);
                 if (_currentHighlightGroup == null)
                 {
-                    if (_parentLogTabWin.HilightGroupList.Count > 0)
+                    if (_parentLogTabWin.HighlightGroupList.Count > 0)
                     {
-                        _currentHighlightGroup = _parentLogTabWin.HilightGroupList[0];
+                        _currentHighlightGroup = _parentLogTabWin.HighlightGroupList[0];
                     }
                     else
                     {
-                        _currentHighlightGroup = new HilightGroup();
+                        _currentHighlightGroup = new HighlightGroup();
                     }
                 }
                 _guiStateArgs.HighlightGroupName = _currentHighlightGroup.GroupName;

--- a/src/LogExpert/Dialogs/HighlightDialog.cs
+++ b/src/LogExpert/Dialogs/HighlightDialog.cs
@@ -156,7 +156,7 @@ namespace LogExpert.Dialogs
             if (dlg.ShowDialog() == DialogResult.OK)
             {
                 FileInfo fileInfo = new(dlg.FileName);
-                ConfigManager.Export(fileInfo);
+                ConfigManager.Export(fileInfo, Core.Config.SettingsFlags.HighlightSettings);
             }
         }
 

--- a/src/LogExpert/Dialogs/SettingsDialog.cs
+++ b/src/LogExpert/Dialogs/SettingsDialog.cs
@@ -352,7 +352,7 @@ namespace LogExpert.Dialogs
             //TODO Remove if not necessary
             DataGridViewTextBoxColumn textColumn = (DataGridViewTextBoxColumn)dataGridViewHighlightMask.Columns[0];
 
-            foreach (HilightGroup group in (IList<HilightGroup>)_logTabWin.HilightGroupList)
+            foreach (HighlightGroup group in (IList<HighlightGroup>)_logTabWin.HighlightGroupList)
             {
                 comboColumn.Items.Add(group.GroupName);
             }
@@ -363,7 +363,7 @@ namespace LogExpert.Dialogs
                 row.Cells.Add(new DataGridViewTextBoxCell());
                 DataGridViewComboBoxCell cell = new();
 
-                foreach (HilightGroup group in (IList<HilightGroup>)_logTabWin.HilightGroupList)
+                foreach (HighlightGroup group in (IList<HighlightGroup>)_logTabWin.HighlightGroupList)
                 {
                     cell.Items.Add(group.GroupName);
                 }
@@ -371,9 +371,9 @@ namespace LogExpert.Dialogs
                 row.Cells.Add(cell);
                 row.Cells[0].Value = maskEntry.mask;
 
-                HilightGroup currentGroup = _logTabWin.FindHighlightGroup(maskEntry.highlightGroupName);
-                currentGroup ??= ((IList<HilightGroup>)_logTabWin.HilightGroupList)[0];
-                currentGroup ??= new HilightGroup();
+                HighlightGroup currentGroup = _logTabWin.FindHighlightGroup(maskEntry.highlightGroupName);
+                currentGroup ??= ((IList<HighlightGroup>)_logTabWin.HighlightGroupList)[0];
+                currentGroup ??= new HighlightGroup();
 
                 row.Cells[1].Value = currentGroup.GroupName;
                 dataGridViewHighlightMask.Rows.Add(row);
@@ -1006,7 +1006,7 @@ namespace LogExpert.Dialogs
         /// <param name="e"></param>
         private void OnBtnImportClick(object sender, EventArgs e)
         {
-            ImportSettingsDialog dlg = new();
+            ImportSettingsDialog dlg = new(ExportImportFlags.All);
 
             if (dlg.ShowDialog() == DialogResult.OK)
             {

--- a/src/LogExpert/Entities/EventArgs/CurrentHighlightGroupChangedEventArgs.cs
+++ b/src/LogExpert/Entities/EventArgs/CurrentHighlightGroupChangedEventArgs.cs
@@ -3,13 +3,13 @@ using LogExpert.Core.Entities;
 
 namespace LogExpert.Entities.EventArgs
 {
-    public class CurrentHighlightGroupChangedEventArgs(LogWindow logWindow, HilightGroup currentGroup)
+    public class CurrentHighlightGroupChangedEventArgs(LogWindow logWindow, HighlightGroup currentGroup)
     {
         #region Properties
 
         public LogWindow LogWindow { get; } = logWindow;
 
-        public HilightGroup CurrentGroup { get; } = currentGroup;
+        public HighlightGroup CurrentGroup { get; } = currentGroup;
 
         #endregion
     }

--- a/src/Logexpert.Core/Classes/Highlight/HighlightEntry.cs
+++ b/src/Logexpert.Core/Classes/Highlight/HighlightEntry.cs
@@ -7,7 +7,7 @@ namespace LogExpert.Core.Classes.Highlight
 {
     [Serializable]
     [method: JsonConstructor]
-    public class HilightEntry() : ICloneable
+    public class HighlightEntry() : ICloneable
     {
         #region Fields
 
@@ -80,7 +80,7 @@ namespace LogExpert.Core.Classes.Highlight
 
         public object Clone()
         {
-            var highLightEntry = new HilightEntry
+            var highLightEntry = new HighlightEntry
             {
                 SearchText = SearchText,
                 ForegroundColor = ForegroundColor,

--- a/src/Logexpert.Core/Classes/Highlight/HilightMatchEntry.cs
+++ b/src/Logexpert.Core/Classes/Highlight/HilightMatchEntry.cs
@@ -7,7 +7,7 @@
     {
         #region Properties
 
-        public HilightEntry HilightEntry { get; set; }
+        public HighlightEntry HilightEntry { get; set; }
 
         public int StartPos { get; set; }
 

--- a/src/Logexpert.Core/Config/ExportImportFlags.cs
+++ b/src/Logexpert.Core/Config/ExportImportFlags.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace LogExpert.Core.Config
 {
     [Flags]

--- a/src/Logexpert.Core/Config/Preferences.cs
+++ b/src/Logexpert.Core/Config/Preferences.cs
@@ -34,6 +34,8 @@ namespace LogExpert.Core.Config
 
         public List<HighlightMaskEntry> highlightMaskList = [];
 
+        public List<HighlightGroup> HighlightGroupList { get; set; } = [];
+
         public bool isAutoHideFilterList = false;
 
         public bool isFilterOnLoad;

--- a/src/Logexpert.Core/Config/Settings.cs
+++ b/src/Logexpert.Core/Config/Settings.cs
@@ -1,9 +1,6 @@
 using LogExpert.Core.Classes.Filter;
-using LogExpert.Core.Classes.Highlight;
 using LogExpert.Core.Entities;
 
-using System;
-using System.Collections.Generic;
 using System.Drawing;
 
 namespace LogExpert.Core.Config
@@ -34,10 +31,6 @@ namespace LogExpert.Core.Config
         public List<string> filterRangeHistoryList = [];
 
         public bool hideLineColumn;
-
-        public List<HilightEntry> hilightEntryList = []; // legacy. is automatically converted to highlight groups on settings load
-
-        public List<HilightGroup> hilightGroupList = []; // should be in Preferences but is here for mistake. Maybe I migrate it some day.
 
         public bool isMaximized;
 

--- a/src/Logexpert.Core/Entities/HighlightGroup.cs
+++ b/src/Logexpert.Core/Entities/HighlightGroup.cs
@@ -3,24 +3,24 @@
 namespace LogExpert.Core.Entities
 {
     [Serializable]
-    public class HilightGroup : ICloneable
+    public class HighlightGroup : ICloneable
     {
         #region Properties
 
         public string GroupName { get; set; } = string.Empty;
 
-        public List<HilightEntry> HilightEntryList { get; set; } = [];
+        public List<HighlightEntry> HighlightEntryList { get; set; } = [];
 
         public object Clone()
         {
-            HilightGroup clone = new()
+            HighlightGroup clone = new()
             {
                 GroupName = GroupName
             };
 
-            foreach (HilightEntry entry in HilightEntryList)
+            foreach (HighlightEntry entry in HighlightEntryList)
             {
-                clone.HilightEntryList.Add((HilightEntry)entry.Clone());
+                clone.HighlightEntryList.Add((HighlightEntry)entry.Clone());
             }
 
             return clone;

--- a/src/Logexpert.Core/Interface/ILogPaintContext.cs
+++ b/src/Logexpert.Core/Interface/ILogPaintContext.cs
@@ -27,7 +27,7 @@ namespace LogExpert.Core.Interface
 
         Bookmark GetBookmarkForLine(int lineNum);
 
-        HilightEntry FindHighlightEntry(ITextValue line, bool noWordMatches);
+        HighlightEntry FindHighlightEntry(ITextValue line, bool noWordMatches);
 
         IList<HilightMatchEntry> FindHighlightMatches(ITextValue line);
 

--- a/src/Logexpert.UI/Dialogs/ImportSettingsDialog.cs
+++ b/src/Logexpert.UI/Dialogs/ImportSettingsDialog.cs
@@ -7,19 +7,33 @@ namespace LogExpert.UI.Dialogs
     [SupportedOSPlatform("windows")]
     public partial class ImportSettingsDialog : Form
     {
-        #region Fields
-
-        #endregion
-
         #region cTor
 
-        public ImportSettingsDialog()
+        public ImportSettingsDialog(ExportImportFlags importFlags)
         {
             InitializeComponent();
-
+            SuspendLayout();
             AutoScaleDimensions = new SizeF(96F, 96F);
             AutoScaleMode = AutoScaleMode.Dpi;
 
+            ImportFlags = importFlags;
+            FileName = string.Empty;
+
+            if (ImportFlags == ExportImportFlags.HighlightSettings)
+            {
+                checkBoxHighlightSettings.Checked = true;
+                checkBoxHighlightSettings.Enabled = false;
+                checkBoxHighlightFileMasks.Checked = false;
+                checkBoxHighlightFileMasks.Enabled = false;
+                checkBoxColumnizerFileMasks.Checked = false;
+                checkBoxColumnizerFileMasks.Enabled = false;
+                checkBoxExternalTools.Checked = false;
+                checkBoxExternalTools.Enabled = false;
+                checkBoxOther.Checked = false;
+                checkBoxOther.Enabled = false;
+            }
+
+            ResumeLayout();
         }
 
         #endregion
@@ -56,17 +70,26 @@ namespace LogExpert.UI.Dialogs
 
         private void OnOkButtonClick(object sender, EventArgs e)
         {
-            ImportFlags = ExportImportFlags.None;
             FileName = textBoxFileName.Text;
 
-            foreach (Control ctl in groupBoxImportOptions.Controls)
+            if (ImportFlags != ExportImportFlags.HighlightSettings)
             {
-                if (ctl.Tag != null)
+                foreach (Control ctl in groupBoxImportOptions.Controls)
                 {
-                    if (((CheckBox)ctl).Checked)
+                    if (ctl.Tag != null)
                     {
-                        ImportFlags |= (ExportImportFlags)long.Parse(ctl.Tag as string ?? string.Empty);
+                        if (((CheckBox)ctl).Checked)
+                        {
+                            ImportFlags |= (ExportImportFlags)long.Parse(ctl.Tag as string ?? string.Empty);
+                        }
                     }
+                }
+            }
+            else
+            {
+                if (checkBoxKeepExistingSettings.Checked)
+                {
+                    ImportFlags |= ExportImportFlags.KeepExisting;
                 }
             }
         }


### PR DESCRIPTION
Fixing the import problem, adapted the import process, now only the highlightgroups and entries are imported from this file.

if other data is present, it will not be able to import

rename the property, this is a breaking change, as older settings will not be importable, unless the names in the json will be changed from "Hilight" to "Highlight"

Export functionality added for the Highlight dialog, this does only export the currently configured highlights to a JSON File.