### PR TITLE
Fix: "Highlight and action triggers" Export function

### DIFF
--- a/src/LogExpert.Resources/Resources.de.resx
+++ b/src/LogExpert.Resources/Resources.de.resx
@@ -233,7 +233,7 @@
 		<value>Exportieren der Einstellungen in eine Datei</value>
 	</data>
   <data name="HighlightDialog_UI_Export_Filter" xml:space="preserve">
-		<value>Einstellungen (*.json)|*.json|Alle Dateien (*.*)</value>
+		<value>Einstellungen (*.json)|*.json|Alle Dateien (*.*)|*.*</value>
 	</data>
   <data name="HighlightDialog_UI_Snippet_CopyOf" xml:space="preserve">
 		<value>Kopie von</value>

--- a/src/LogExpert.Resources/Resources.resx
+++ b/src/LogExpert.Resources/Resources.resx
@@ -239,7 +239,7 @@
         <value>Export Settings to file</value>
     </data>
   <data name="HighlightDialog_UI_Export_Filter" xml:space="preserve">
-        <value>Settings (*.json)|*.json|All files (*.*)</value>
+        <value>Settings (*.json)|*.json|All files (*.*)|*.*</value>
     </data>
   <data name="HighlightDialog_UI_Snippet_CopyOf" xml:space="preserve">
         <value>Copy of</value>

--- a/src/LogExpert.Resources/Resources.zh-CN.resx
+++ b/src/LogExpert.Resources/Resources.zh-CN.resx
@@ -148,7 +148,7 @@
     <value>导出设置到文件</value>
   </data>
   <data name="HighlightDialog_UI_Export_Filter" xml:space="preserve">
-    <value>设置文件 (*.json)|*.json|所有文件 (*.*)</value>
+    <value>设置文件 (*.json)|*.json|所有文件 (*.*)|*.*</value>
   </data>
   <data name="HighlightDialog_UI_Snippet_CopyOf" xml:space="preserve">
     <value>复制为</value>


### PR DESCRIPTION
"Highlighting and action triggers" Export function was causing unhandled error exception. The filter now uses valid description|pattern pairs, so exporting highlight groups no longer throws an error dialog.

<img width="577" height="444" alt="image" src="https://github.com/user-attachments/assets/e0898067-9270-4e5c-9f85-7c4ad74e9f34" />
