### PR TITLE
Fix configured encoding fallback and add Windows-1250 option (2)

### DIFF
--- a/src/LogExpert.Core/Classes/Log/LogfileReader.cs
+++ b/src/LogExpert.Core/Classes/Log/LogfileReader.cs
@@ -190,7 +190,9 @@ public partial class LogfileReader : ILogfileReader, IMultiFileNavigation, ILogf
         {
             try
             {
-                _mmfReader = new MemoryMappedFileReader(_watchedILogFileInfo.FullName, EncodingOptions.Encoding ?? Encoding.Default);
+                // Keep the memory-mapped reader aligned with the stream reader fallback order:
+                // explicit/persisted encoding, application default, then machine default.
+                _mmfReader = new MemoryMappedFileReader(_watchedILogFileInfo.FullName, EncodingOptions.Encoding ?? EncodingOptions.DefaultEncoding ?? Encoding.Default);
             }
             catch (IOException)
             {

--- a/src/LogExpert.Core/Classes/Log/LogfileReader.cs
+++ b/src/LogExpert.Core/Classes/Log/LogfileReader.cs
@@ -190,9 +190,11 @@ public partial class LogfileReader : ILogfileReader, IMultiFileNavigation, ILogf
         {
             try
             {
-                // Keep the memory-mapped reader aligned with the stream reader fallback order:
-                // explicit/persisted encoding, application default, then machine default.
-                _mmfReader = new MemoryMappedFileReader(_watchedILogFileInfo.FullName, EncodingOptions.Encoding ?? EncodingOptions.DefaultEncoding ?? Encoding.Default);
+                using var stream = new FileStream(_watchedILogFileInfo.FullName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                var (preambleLength, detectedEncoding) = PositionAwareStreamReaderBase.DetectPreambleLength(stream);
+                var encoding = PositionAwareStreamReaderBase.DetermineEncoding(EncodingOptions, detectedEncoding);
+
+                _mmfReader = new MemoryMappedFileReader(_watchedILogFileInfo.FullName, encoding, preambleLength);
             }
             catch (IOException)
             {

--- a/src/LogExpert.Core/Classes/Log/MemoryMappedFileReader.cs
+++ b/src/LogExpert.Core/Classes/Log/MemoryMappedFileReader.cs
@@ -10,9 +10,10 @@ namespace LogExpert.Core.Classes.Log;
 /// Reads log lines via memory-mapped file access. Builds a line-offset index on load.
 /// Supports tail mode by re-mapping when the file grows.
 /// </summary>
-internal sealed class MemoryMappedFileReader (string filePath, Encoding encoding) : IDisposable
+internal sealed class MemoryMappedFileReader (string filePath, Encoding encoding, int preambleLength) : IDisposable
 {
     private readonly Encoding _encoding = encoding;
+    private readonly int _preambleLength = preambleLength;
     private readonly LineOffsetIndex _lineIndex = new();
     private MemoryMappedFile _mmf;
     private MemoryMappedViewAccessor _accessor;
@@ -33,7 +34,7 @@ internal sealed class MemoryMappedFileReader (string filePath, Encoding encoding
         if (startOffset == 0)
         {
             _lineIndex.Clear();
-            _lineIndex.Add(0); // first line starts at offset 0
+            _lineIndex.Add(_preambleLength); // Skip the BOM, when present, just like StreamReader.
         }
 
         fs.Position = startOffset;

--- a/src/LogExpert.Core/Classes/Log/Streamreaders/PositionAwareStreamReaderBase.cs
+++ b/src/LogExpert.Core/Classes/Log/Streamreaders/PositionAwareStreamReaderBase.cs
@@ -165,9 +165,8 @@ public abstract class PositionAwareStreamReaderBase : LogStreamReaderBase
 
     public static Encoding DetermineEncoding (EncodingOptions options, Encoding detectedEncoding)
     {
-        return options?.Encoding != null
-            ? options.Encoding
-            : detectedEncoding ?? options?.DefaultEncoding ?? Encoding.Default;
+        // A BOM describes the file itself, so it takes precedence over persisted or configured choices.
+        return detectedEncoding ?? options?.Encoding ?? options?.DefaultEncoding ?? Encoding.Default;
     }
 
     /// <summary>

--- a/src/LogExpert.Core/Classes/Log/Streamreaders/PositionAwareStreamReaderBase.cs
+++ b/src/LogExpert.Core/Classes/Log/Streamreaders/PositionAwareStreamReaderBase.cs
@@ -165,8 +165,9 @@ public abstract class PositionAwareStreamReaderBase : LogStreamReaderBase
 
     public static Encoding DetermineEncoding (EncodingOptions options, Encoding detectedEncoding)
     {
-        // A BOM describes the file itself, so it takes precedence over persisted or configured choices.
-        return detectedEncoding ?? options?.Encoding ?? options?.DefaultEncoding ?? Encoding.Default;
+        // An explicit/persisted encoding also represents a manual Encoding-menu choice.
+        // Without one, use the file BOM before the configured and machine defaults.
+        return options?.Encoding ?? detectedEncoding ?? options?.DefaultEncoding ?? Encoding.Default;
     }
 
     /// <summary>

--- a/src/LogExpert.Tests/Dialogs/SettingsDialogPortableModeTests.cs
+++ b/src/LogExpert.Tests/Dialogs/SettingsDialogPortableModeTests.cs
@@ -1,3 +1,6 @@
+using System.Text;
+
+using LogExpert;
 using LogExpert.Core.Config;
 using LogExpert.Core.Interfaces;
 using LogExpert.Dialogs;
@@ -19,6 +22,16 @@ namespace LogExpert.Tests.Dialogs;
 [TestFixture]
 public class SettingsDialogPortableModeTests
 {
+    [Test]
+    public void AvailableEncodings_ContainsWindows1250 ()
+    {
+        Program.RegisterEncodingProvider();
+
+        var encodings = SettingsDialog.GetAvailableEncodings();
+
+        Assert.That(encodings.Select(encoding => encoding.CodePage), Does.Contain(1250));
+    }
+
     private string _testDataPath = null!;
     private string _portableConfigDir = null!;
 

--- a/src/LogExpert.Tests/IPC/OneInstanceIpcTests.cs
+++ b/src/LogExpert.Tests/IPC/OneInstanceIpcTests.cs
@@ -1,3 +1,6 @@
+using System.Text;
+
+using LogExpert;
 using LogExpert.Core.Classes.IPC;
 
 using Newtonsoft.Json;
@@ -13,6 +16,14 @@ namespace LogExpert.Tests.IPC;
 [TestFixture]
 public class OneInstanceIpcTests
 {
+    [Test]
+    public void RegisterEncodingProvider_MakesWindows1252Available ()
+    {
+        Program.RegisterEncodingProvider();
+
+        Assert.That(Encoding.GetEncoding(1252).CodePage, Is.EqualTo(1252));
+    }
+
     #region IPC Message Type Tests
 
     [Test]

--- a/src/LogExpert.Tests/StreamReaderTests/LogfileReaderBlockAllocationTests.cs
+++ b/src/LogExpert.Tests/StreamReaderTests/LogfileReaderBlockAllocationTests.cs
@@ -16,6 +16,7 @@ public class LogfileReaderBlockAllocationTests
     [SetUp]
     public void Setup ()
     {
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
         _tempFile = Path.GetTempFileName();
         _ = PluginRegistry.PluginRegistry.Create(Path.GetDirectoryName(_tempFile)!, 500);
     }
@@ -227,6 +228,60 @@ public class LogfileReaderBlockAllocationTests
         {
             VerifyLine(reader, i, i);
         }
+    }
+
+    [Test]
+    public void ReadFiles_BomlessFile_UsesConfiguredDefaultEncoding ()
+    {
+        var configuredEncoding = Encoding.GetEncoding(1252);
+        File.WriteAllText(_tempFile, "Euro: €\n", configuredEncoding);
+
+        using var reader = CreateReader(new EncodingOptions { DefaultEncoding = configuredEncoding });
+        reader.ReadFiles();
+
+        Assert.That(reader.CurrentEncoding.CodePage, Is.EqualTo(configuredEncoding.CodePage));
+        Assert.That(reader.GetLogLineMemory(0)?.FullLine.Span.ToString(), Is.EqualTo("Euro: €"));
+    }
+
+    [Test]
+    public void ReadFiles_Bom_OverridesConfiguredDefaultEncoding ()
+    {
+        var configuredEncoding = Encoding.GetEncoding(1252);
+        File.WriteAllText(_tempFile, "Euro: €\n", Encoding.UTF8);
+
+        using var reader = CreateReader(new EncodingOptions { DefaultEncoding = configuredEncoding });
+        reader.ReadFiles();
+
+        Assert.That(reader.CurrentEncoding.WebName, Is.EqualTo(Encoding.UTF8.WebName));
+        Assert.That(reader.GetLogLineMemory(0)?.FullLine.Span.ToString(), Is.EqualTo("Euro: €"));
+    }
+
+    [Test]
+    public void ReadFiles_ExplicitEncoding_OverridesBom ()
+    {
+        var explicitEncoding = Encoding.GetEncoding(1252);
+        File.WriteAllText(_tempFile, "ASCII text\n", Encoding.UTF8);
+
+        using var reader = CreateReader(new EncodingOptions { Encoding = explicitEncoding });
+        reader.ReadFiles();
+
+        Assert.That(reader.CurrentEncoding.CodePage, Is.EqualTo(explicitEncoding.CodePage));
+        Assert.That(reader.GetLogLineMemory(0)?.FullLine.Span.ToString(), Is.EqualTo("ASCII text"));
+    }
+
+    private LogfileReader CreateReader (EncodingOptions encodingOptions)
+    {
+        return new LogfileReader(
+            _tempFile,
+            encodingOptions,
+            multiFile: false,
+            bufferCount: 100,
+            linesPerBuffer: 500,
+            new MultiFileOptions(),
+            ReaderType.System,
+            PluginRegistry.PluginRegistry.Instance,
+            maximumLineLength: 500,
+            progressReporter: Core.Classes.Log.ProgressReporters.NullProgressReporter.Instance);
     }
 
     private static void VerifyLine (LogfileReader reader, int lineNum, int expectedIndex)

--- a/src/LogExpert.UI/Dialogs/SettingsDialog.cs
+++ b/src/LogExpert.UI/Dialogs/SettingsDialog.cs
@@ -693,7 +693,7 @@ internal partial class SettingsDialog : Form
     /// </summary>
     /// <remarks>
     /// This method clears any existing items in the combo box and adds a selection of common encodings, including
-    /// ASCII, Default (UTF-8), ISO-8859-1, UTF-8, Unicode, and Windows-1252. The value member of the combo box is set
+    /// ASCII, Default (UTF-8), ISO-8859-1, UTF-8, Unicode, Windows-1250, and Windows-1252. The value member of the combo box is set
     /// to a specific header name defined in the resources.
     /// </remarks>
     private void FillEncodingList ()
@@ -705,6 +705,7 @@ internal partial class SettingsDialog : Form
         _ = comboBoxEncoding.Items.Add(Encoding.GetEncoding("iso-8859-1"));
         _ = comboBoxEncoding.Items.Add(Encoding.UTF8);
         _ = comboBoxEncoding.Items.Add(Encoding.Unicode);
+        _ = comboBoxEncoding.Items.Add(CodePagesEncodingProvider.Instance.GetEncoding(1250));
         _ = comboBoxEncoding.Items.Add(CodePagesEncodingProvider.Instance.GetEncoding(1252));
 
         comboBoxEncoding.ValueMember = Resources.SettingsDialog_UI_ComboBox_Encoding_ValueMember_HeaderName;

--- a/src/LogExpert.UI/Dialogs/SettingsDialog.cs
+++ b/src/LogExpert.UI/Dialogs/SettingsDialog.cs
@@ -86,8 +86,6 @@ internal partial class SettingsDialog : Form
 
         LoadResources();
 
-        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
-
         ResumeLayout();
     }
 
@@ -700,15 +698,29 @@ internal partial class SettingsDialog : Form
     {
         comboBoxEncoding.Items.Clear();
 
-        _ = comboBoxEncoding.Items.Add(Encoding.ASCII);
-        _ = comboBoxEncoding.Items.Add(Encoding.Default);
-        _ = comboBoxEncoding.Items.Add(Encoding.GetEncoding("iso-8859-1"));
-        _ = comboBoxEncoding.Items.Add(Encoding.UTF8);
-        _ = comboBoxEncoding.Items.Add(Encoding.Unicode);
-        _ = comboBoxEncoding.Items.Add(CodePagesEncodingProvider.Instance.GetEncoding(1250));
-        _ = comboBoxEncoding.Items.Add(CodePagesEncodingProvider.Instance.GetEncoding(1252));
+        foreach (var encoding in GetAvailableEncodings())
+        {
+            _ = comboBoxEncoding.Items.Add(encoding);
+        }
 
         comboBoxEncoding.ValueMember = Resources.SettingsDialog_UI_ComboBox_Encoding_ValueMember_HeaderName;
+    }
+
+    /// <summary>
+    /// Gets the encodings offered in the Preferences dropdown.
+    /// </summary>
+    internal static IReadOnlyList<Encoding> GetAvailableEncodings ()
+    {
+        return
+        [
+            Encoding.ASCII,
+            Encoding.Default,
+            Encoding.GetEncoding("iso-8859-1"),
+            Encoding.UTF8,
+            Encoding.Unicode,
+            Encoding.GetEncoding(1250),
+            Encoding.GetEncoding(1252)
+        ];
     }
 
     /// <summary>

--- a/src/LogExpert.UI/Services/FileOperationService/FileOperationService.cs
+++ b/src/LogExpert.UI/Services/FileOperationService/FileOperationService.cs
@@ -120,10 +120,6 @@ internal sealed class FileOperationService (
 
     private void FillDefaultEncodingFromSettings (EncodingOptions encodingOptions)
     {
-        // Legacy Windows code pages such as windows-1252 are configured in Preferences.DefaultEncoding.
-        // Register the provider here because a file can be opened before the Settings dialog is ever shown.
-        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
-
         if (_configManager.Settings.Preferences.DefaultEncoding != null)
         {
             try

--- a/src/LogExpert.UI/Services/FileOperationService/FileOperationService.cs
+++ b/src/LogExpert.UI/Services/FileOperationService/FileOperationService.cs
@@ -120,6 +120,10 @@ internal sealed class FileOperationService (
 
     private void FillDefaultEncodingFromSettings (EncodingOptions encodingOptions)
     {
+        // Legacy Windows code pages such as windows-1252 are configured in Preferences.DefaultEncoding.
+        // Register the provider here because a file can be opened before the Settings dialog is ever shown.
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+
         if (_configManager.Settings.Preferences.DefaultEncoding != null)
         {
             try

--- a/src/LogExpert/Program.cs
+++ b/src/LogExpert/Program.cs
@@ -54,6 +54,8 @@ internal static class Program
         Application.EnableVisualStyles();
         Application.SetUnhandledExceptionMode(UnhandledExceptionMode.CatchException);
 
+        RegisterEncodingProvider();
+
         // Register the plugin assembly resolver early so that settings deserialization
         // can find plugin types (e.g., CsvColumnizer) before PluginRegistry.Create() runs.
         PluginRegistry.PluginRegistry.RegisterAssemblyResolver();
@@ -259,6 +261,14 @@ internal static class Program
         {
             Application.SetColorMode(SystemColorMode.System);
         }
+    }
+
+    /// <summary>
+    /// Makes legacy Windows code pages configured in preferences available before settings are read.
+    /// </summary>
+    internal static void RegisterEncodingProvider ()
+    {
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
     }
 
     [SupportedOSPlatform("windows")]


### PR DESCRIPTION
Attempt nr.2 (from #671)
I am trying to rewrite changes from previous pull request #671. When tested these changes, the Logexpert was able to correctly save encoding stored in app setting into .lxp file of newly opened non-BOM file (encoded in Windows-1252). 
When UTF-8 BOM file was opened (also first time), correct utf-8 encoding was saved regardless app setting, which is requested behaviour.


I am not saying this fix is perfect, but I was able to get final result to requirement, at least I think so :). This project is so complex and its hard to look/search everywhere, at least for me. If you are convinced this fix is not correct, please do it your way. I am tust trying to make this app better.