### PR TITLE
refactor: anchor build output paths on the repo instead of $(SolutionDir)

### DIFF
--- a/src/AutoColumnizer/AutoColumnizer.csproj
+++ b/src/AutoColumnizer/AutoColumnizer.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
 
     <AssemblyTitle>AutoColumnizer</AssemblyTitle>
-    <OutputPath>$(SolutionDir)..\bin\$(Configuration)\plugins</OutputPath>
+    <OutputPath>$(LogExpertPluginsDirectory)</OutputPath>
     <RootNamespace>AutoColumnizer</RootNamespace>
   </PropertyGroup>
 

--- a/src/ColumnizerLib.UnitTests/LogExpert.ColumnizerLib.Tests.csproj
+++ b/src/ColumnizerLib.UnitTests/LogExpert.ColumnizerLib.Tests.csproj
@@ -5,7 +5,6 @@
     <IsTestProject>true</IsTestProject>
     <AssemblyTitle>ColumnizerLib.Tests</AssemblyTitle>
     <Company>Microsoft</Company>
-    <OutputPath>bin\$(Configuration)</OutputPath>
     <RootNamespace>LogExpert.ColumnizerLib.Tests</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/src/ColumnizerLib/ColumnizerLib.csproj
+++ b/src/ColumnizerLib/ColumnizerLib.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
 
-    <DocumentationFile>$(SolutionDir)..\bin\Docs\ColumnizerLib.xml</DocumentationFile>
+    <DocumentationFile>$(LogExpertDocsDirectory)ColumnizerLib.xml</DocumentationFile>
 
     <RootNamespace>ColumnizerLib</RootNamespace>
 

--- a/src/CsvColumnizer/CsvColumnizer.csproj
+++ b/src/CsvColumnizer/CsvColumnizer.csproj
@@ -1,11 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0-windows</TargetFramework>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
 
     <UseWindowsForms>true</UseWindowsForms>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
-    <OutputPath>$(SolutionDir)..\bin\$(Configuration)\plugins</OutputPath>
+    <OutputPath>$(LogExpertPluginsDirectory)</OutputPath>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <AssemblyTitle>CsvColumnizer</AssemblyTitle>
     <RootNamespace>CsvColumnizer</RootNamespace>

--- a/src/DefaultPlugins/DefaultPlugins.csproj
+++ b/src/DefaultPlugins/DefaultPlugins.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
 
-    <OutputPath>$(SolutionDir)..\bin\$(Configuration)\plugins</OutputPath>
+    <OutputPath>$(LogExpertPluginsDirectory)</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,7 +15,27 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>LogExpert</RootNamespace>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <!--<OutputPath>$(SolutionDir)..\bin\$(Configuration)</OutputPath>--><!--TODO: Normalize this across solution-->
+
+    <!--
+      Where everything that ships is built. Anchored on this file rather than $(SolutionDir), which
+      is only defined when MSBuild is driven by the .sln: building a single project used to resolve
+      the same "$(SolutionDir)..\bin\..." to src\bin\ instead, so a lone `dotnet build Foo.csproj`
+      silently wrote somewhere other than the solution build - and the Nuke targets, the installer
+      and the CI artifact all look in bin\. Projects that do not ship (tests, benchmarks, the Nuke
+      build) keep the SDK default of a project-local bin\ and should not use these.
+
+      Configuration is defaulted here because this file is imported before the SDK gets round to
+      defaulting it, and an empty value would silently collapse bin\Debug\ to bin\. Same value the
+      SDK would pick, and the condition means an explicit -c or a solution build still wins.
+    -->
+    <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
+    <LogExpertBinRoot>$(MSBuildThisFileDirectory)..\bin\</LogExpertBinRoot>
+    <LogExpertBinDirectory>$(LogExpertBinRoot)$(Configuration)\</LogExpertBinDirectory>
+    <LogExpertPluginsDirectory>$(LogExpertBinDirectory)plugins\</LogExpertPluginsDirectory>
+    <LogExpertPluginsX86Directory>$(LogExpertBinDirectory)pluginsx86\</LogExpertPluginsX86Directory>
+    <!-- Deliberately outside the per-configuration folder; that is where it has always been. -->
+    <LogExpertDocsDirectory>$(LogExpertBinRoot)Docs\</LogExpertDocsDirectory>
+
     <SignAssembly>true</SignAssembly>
     <PackageProjectUrl>https://github.com/LogExperts/LogExpert</PackageProjectUrl>
     <RepositoryUrl>https://github.com/LogExperts/LogExpert</RepositoryUrl>

--- a/src/FlashIconHighlighter/FlashIconHighlighter.csproj
+++ b/src/FlashIconHighlighter/FlashIconHighlighter.csproj
@@ -1,11 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0-windows</TargetFramework>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <UseWindowsForms>true</UseWindowsForms>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
-    <OutputPath>$(SolutionDir)..\bin\$(Configuration)\plugins</OutputPath>
+    <OutputPath>$(LogExpertPluginsDirectory)</OutputPath>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyTitle>FlashIconHighlighter</AssemblyTitle>
     <RootNamespace>FlashIconHighlighter</RootNamespace>

--- a/src/GlassfishColumnizer/GlassfishColumnizer.csproj
+++ b/src/GlassfishColumnizer/GlassfishColumnizer.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
 
-    <OutputPath>$(SolutionDir)..\bin\$(Configuration)\plugins</OutputPath>
+    <OutputPath>$(LogExpertPluginsDirectory)</OutputPath>
     <AssemblyTitle>GlassfishColumnizer</AssemblyTitle>
     <Description>Glassfish logfile support for LogExpert</Description>
     <RootNamespace>GlassfishColumnizer</RootNamespace>

--- a/src/JsonColumnizer/JsonColumnizer.csproj
+++ b/src/JsonColumnizer/JsonColumnizer.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
 
-    <OutputPath>$(SolutionDir)..\bin\$(Configuration)\plugins</OutputPath>
+    <OutputPath>$(LogExpertPluginsDirectory)</OutputPath>
     <AssemblyTitle>JsonColumnizer</AssemblyTitle>
     <RootNamespace>JsonColumnizer</RootNamespace>
   </PropertyGroup>

--- a/src/JsonCompactColumnizer/JsonCompactColumnizer.csproj
+++ b/src/JsonCompactColumnizer/JsonCompactColumnizer.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
 
     <RootNamespace>JsonCompactColumnizer</RootNamespace>
-    <OutputPath>$(SolutionDir)..\bin\$(Configuration)\plugins</OutputPath>
+    <OutputPath>$(LogExpertPluginsDirectory)</OutputPath>
     <AssemblyTitle>JsonCompactColumnizer</AssemblyTitle>
   </PropertyGroup>
 

--- a/src/Log4jXmlColumnizer/Log4jXmlColumnizer.csproj
+++ b/src/Log4jXmlColumnizer/Log4jXmlColumnizer.csproj
@@ -1,11 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0-windows</TargetFramework>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
 
     <UseWindowsForms>true</UseWindowsForms>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
-    <OutputPath>$(SolutionDir)..\bin\$(Configuration)\plugins</OutputPath>
+    <OutputPath>$(LogExpertPluginsDirectory)</OutputPath>
     <AssemblyTitle>Log4jXmlColumnizer</AssemblyTitle>
     <RootNamespace>Log4jXmlColumnizer</RootNamespace>
   </PropertyGroup>

--- a/src/LogExpert.Tests/LogExpert.Tests.csproj
+++ b/src/LogExpert.Tests/LogExpert.Tests.csproj
@@ -7,7 +7,6 @@
     <IsTestProject>true</IsTestProject>
     <UseWindowsForms>true</UseWindowsForms>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
-    <OutputPath>bin\$(Configuration)</OutputPath>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <AssemblyTitle>LogExpert.Tests</AssemblyTitle>
     <RootNamespace>LogExpert.Tests</RootNamespace>

--- a/src/LogExpert/LogExpert.csproj
+++ b/src/LogExpert/LogExpert.csproj
@@ -1,13 +1,13 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
     <ApplicationIcon>logexpert.ico</ApplicationIcon>
     <CopyLocalLockFileAssemblies>True</CopyLocalLockFileAssemblies>
-    <DocumentationFile>$(SolutionDir)..\bin\Docs\LogExpert.xml</DocumentationFile>
+    <DocumentationFile>$(LogExpertDocsDirectory)LogExpert.xml</DocumentationFile>
     <EnableWindowsTargeting>True</EnableWindowsTargeting>
     <ForceDesignerDPIUnaware>True</ForceDesignerDPIUnaware>
     <GenerateSerializationAssemblies>Auto</GenerateSerializationAssemblies>
-    <OutputPath>$(SolutionDir)..\bin\$(Configuration)</OutputPath>
+    <OutputPath>$(LogExpertBinDirectory)</OutputPath>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net10.0-windows</TargetFramework>
     <UseWindowsForms>False</UseWindowsForms>

--- a/src/PluginRegistry.Tests/LogExpert.PluginRegistry.Tests.csproj
+++ b/src/PluginRegistry.Tests/LogExpert.PluginRegistry.Tests.csproj
@@ -8,7 +8,6 @@
     <IsTestProject>true</IsTestProject>
     <AssemblyTitle>LogExpert.PluginRegistry.Tests</AssemblyTitle>
     <Company>Microsoft</Company>
-    <OutputPath>bin\$(Configuration)</OutputPath>
     <RootNamespace>LogExpert.PluginRegistry.Tests</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/src/PluginRegistry/PluginHashGenerator.targets
+++ b/src/PluginRegistry/PluginHashGenerator.targets
@@ -11,14 +11,12 @@
     Generating it rather than committing it is the point: a committed table describes whichever
     build produced it, so it went stale the moment it was committed and never matched the binaries
     it shipped beside. Nothing here depends on builds being byte-reproducible across commits.
+
+    LogExpertPluginsDirectory / LogExpertPluginsX86Directory come from Directory.Build.props and are
+    the very directories the plugin projects build into, so the two cannot drift apart.
   -->
 
   <PropertyGroup>
-    <!-- The same expression the plugin projects use for OutputPath. PluginRegistry sits at the same
-         directory level as they do, so this resolves to the same place whether the solution or a
-         lone project is being built (SolutionDir is only defined for the former). -->
-    <BuiltInPluginsDirectory>$(SolutionDir)..\bin\$(Configuration)\plugins\</BuiltInPluginsDirectory>
-    <BuiltInPluginsX86Directory>$(SolutionDir)..\bin\$(Configuration)\pluginsx86\</BuiltInPluginsX86Directory>
     <!-- Spelled out from BaseIntermediateOutputPath rather than using IntermediateOutputPath: this
          file is imported before the SDK's common targets define the latter, so it would evaluate
          empty here and drop the generated file into the project directory. Per-configuration so
@@ -74,21 +72,21 @@ public static partial class PluginValidator
          alongside bare %(Filename) metadata makes MSBuild batch the item element over
          NonPluginAssembly, which silently resolves the metadata against the wrong item. -->
     <PropertyGroup>
-      <ExcludedFromPlugins>@(NonPluginAssembly->'$(BuiltInPluginsDirectory)%(Identity)')</ExcludedFromPlugins>
-      <ExcludedFromPluginsX86>@(NonPluginAssembly->'$(BuiltInPluginsX86Directory)%(Identity)')</ExcludedFromPluginsX86>
+      <ExcludedFromPlugins>@(NonPluginAssembly->'$(LogExpertPluginsDirectory)%(Identity)')</ExcludedFromPlugins>
+      <ExcludedFromPluginsX86>@(NonPluginAssembly->'$(LogExpertPluginsX86Directory)%(Identity)')</ExcludedFromPluginsX86>
     </PropertyGroup>
 
     <!-- Globbed inside the target, not at evaluation: the plugins are built during this same build,
          so at evaluation time they may not exist yet. Kept as two lists because the x86 entries need
          a suffixed key, which the transforms below apply. -->
     <ItemGroup>
-      <BuiltInPlugin Include="$(BuiltInPluginsDirectory)*.dll" Exclude="$(ExcludedFromPlugins)" />
-      <BuiltInPluginX86 Include="$(BuiltInPluginsX86Directory)*.dll" Exclude="$(ExcludedFromPluginsX86)" />
+      <BuiltInPlugin Include="$(LogExpertPluginsDirectory)*.dll" Exclude="$(ExcludedFromPlugins)" />
+      <BuiltInPluginX86 Include="$(LogExpertPluginsX86Directory)*.dll" Exclude="$(ExcludedFromPluginsX86)" />
     </ItemGroup>
 
     <!-- An empty table would silently make every built-in plugin untrusted, so fail loudly instead. -->
     <Error Condition="'@(BuiltInPlugin)' == ''"
-           Text="No built-in plugin assemblies found in $(BuiltInPluginsDirectory). The plugin projects should have been built first - check the build-order ProjectReferences in LogExpert.PluginRegistry.csproj." />
+           Text="No built-in plugin assemblies found in $(LogExpertPluginsDirectory). The plugin projects should have been built first - check the build-order ProjectReferences in LogExpert.PluginRegistry.csproj." />
 
     <GetFileHash Files="@(BuiltInPlugin)" Algorithm="SHA256" HashEncoding="hex">
       <Output TaskParameter="Items" ItemName="HashedBuiltInPlugin" />

--- a/src/RegexColumnizer.UnitTests/LogExpert.RegexColumnizer.Tests.csproj
+++ b/src/RegexColumnizer.UnitTests/LogExpert.RegexColumnizer.Tests.csproj
@@ -4,7 +4,6 @@
 
     <IsTestProject>true</IsTestProject>
 
-    <OutputPath>bin\$(Configuration)</OutputPath>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <AssemblyTitle>RegexColumnizer.Tests</AssemblyTitle>
     <RootNamespace>LogExpert.RegexColumnizer.Tests</RootNamespace>

--- a/src/RegexColumnizer/RegexColumnizer.csproj
+++ b/src/RegexColumnizer/RegexColumnizer.csproj
@@ -1,11 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0-windows</TargetFramework>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
 
     <UseWindowsForms>true</UseWindowsForms>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
-    <OutputPath>$(SolutionDir)..\bin\$(Configuration)\plugins</OutputPath>
+    <OutputPath>$(LogExpertPluginsDirectory)</OutputPath>
     <AssemblyTitle>RegexColumnizer</AssemblyTitle>
     <RootNamespace>RegexColumnizer</RootNamespace>
   </PropertyGroup>

--- a/src/SftpFileSystemx64/SftpFileSystemx64.csproj
+++ b/src/SftpFileSystemx64/SftpFileSystemx64.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0-windows</TargetFramework>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
@@ -8,7 +8,7 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <OutputPath>$(SolutionDir)..\bin\$(Configuration)\plugins</OutputPath>
+    <OutputPath>$(LogExpertPluginsDirectory)</OutputPath>
     <AssemblyTitle>SftpFileSystem</AssemblyTitle>
   </PropertyGroup>
 

--- a/src/SftpFileSystemx86/SftpFileSystemx86.csproj
+++ b/src/SftpFileSystemx86/SftpFileSystemx86.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0-windows</TargetFramework>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
@@ -9,7 +9,7 @@
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <AssemblyTitle>SftpFileSystemx86</AssemblyTitle>
-    <OutputPath>$(SolutionDir)..\bin\$(Configuration)\pluginsx86</OutputPath>
+    <OutputPath>$(LogExpertPluginsX86Directory)</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
refactor: anchor build output paths on the repo instead of $(SolutionDir)

Closes the "TODO: Normalize this across solution" on the commented-out OutputPath in Directory.Build.props.

 $(SolutionDir) is only defined when MSBuild is driven by the .sln. Fourteen projects spelled their output as "$(SolutionDir)..\bin\...", so under a solution build that resolved to bin\, but a lone `dotnet build Foo.csproj` resolved the same text relative to the project and quietly wrote to src\bin\ instead - while the Nuke targets, the installer file list and the CI artifact all look in bin\. Nothing failed; the single-project build just stopped agreeing with everything else. It cost real time during the plugin-hash work, where a lone build looked reproducible only because the file being hashed was a stale leftover.

Anchor the paths on $(MSBuildThisFileDirectory) instead and name them once:

  LogExpertBinRoot / LogExpertBinDirectory / LogExpertPluginsDirectory /
  LogExpertPluginsX86Directory / LogExpertDocsDirectory

Configuration has to be defaulted alongside them: Directory.Build.props is imported before the SDK defaults it, and an empty value silently collapses bin\Debug\ to bin\. The condition leaves an explicit -c or a solution build untouched.

Also folded in:
- the two DocumentationFile paths, which had the same $(SolutionDir) defect
- four test projects that hand-wrote <OutputPath>bin\$(Configuration)</OutputPath>, which is exactly the SDK default once AppendTargetFrameworkToOutputPath=false
- PluginHashGenerator.targets now reads the shared properties rather than re-deriving the plugins directory, so the two cannot drift apart

The $(SolutionDir) use left in src/SDK/ is deliberate: those samples are built from their own solution by plugin authors, not by ours.

Output layout is unchanged - verified byte-for-byte against a pre-change snapshot: same 18 directories under bin/Release, same 65 files at its root, 19 plugins, 10 pluginsx86, both XMLs in bin/Docs. Lone builds of AutoColumnizer, SftpFileSystemx86, ColumnizerLib and LogExpert now land there too and no longer create src\bin. Plugin hash table still 21 entries in both configurations, all matching the shipped binaries. 