### PR TITLE
Fix/encoding dropdown duplicate utf8

### DIFF
--- a/src/LogExpert.Configuration/ConfigManager.cs
+++ b/src/LogExpert.Configuration/ConfigManager.cs
@@ -657,7 +657,9 @@ public class ConfigManager : IConfigManager
 
         settings.Preferences.MultiFileOptions ??= new MultiFileOptions();
 
-        settings.Preferences.DefaultEncoding ??= System.Text.Encoding.Default.HeaderName;
+        // UTF-8 rather than Encoding.Default: identical text on .NET, but Encoding.Default is not one of
+        // the rows the Preferences dropdown offers, so seeding from it would name an unselectable entry.
+        settings.Preferences.DefaultEncoding ??= System.Text.Encoding.UTF8.HeaderName;
 
         settings.Preferences.DefaultLanguage ??= CultureInfo.GetCultureInfo("en-US").Name;
 

--- a/src/LogExpert.Tests/Dialogs/SettingsDialogEncodingListTests.cs
+++ b/src/LogExpert.Tests/Dialogs/SettingsDialogEncodingListTests.cs
@@ -44,4 +44,83 @@ public class SettingsDialogEncodingListTests
             }
         });
     }
+
+    /// <summary>
+    /// The dropdown renders each entry as its <see cref="Encoding.HeaderName"/>, so two entries sharing a
+    /// code page are two rows the user cannot tell apart. <c>Encoding.Default</c> and
+    /// <see cref="Encoding.UTF8"/> are both code page 65001 on .NET and both read <c>utf-8</c>.
+    /// </summary>
+    [Test]
+    public void GetAvailableEncodings_NoTwoEntriesShareACodePage ()
+    {
+        var codePages = SettingsDialog.GetAvailableEncodings().Select(encoding => encoding.CodePage);
+
+        Assert.That(codePages, Is.Unique);
+    }
+
+    /// <summary>
+    /// The selection is persisted by name and restored with
+    /// <c>comboBoxEncoding.SelectedItem = EncodingRegistry.GetEncoding(name, …)</c>. WinForms locates that
+    /// item with <see cref="object.Equals(object)"/>, so an entry whose name resolves back to an instance
+    /// that is not equal to it can never be reselected — the row goes dead after the first restart.
+    /// </summary>
+    [Test]
+    public void GetAvailableEncodings_EveryEntryIsReselectableAfterARoundTrip ()
+    {
+        var encodings = SettingsDialog.GetAvailableEncodings();
+
+        Assert.Multiple(() =>
+        {
+            foreach (var encoding in encodings)
+            {
+                var restored = EncodingRegistry.GetEncoding(encoding.HeaderName, SettingsDialog.FallbackEncoding);
+
+                Assert.That(
+                    restored,
+                    Is.EqualTo(encoding),
+                    $"picking '{encoding.HeaderName}' saves a name that reselects a different entry");
+            }
+        });
+    }
+
+    /// <summary>
+    /// <c>FillDialog</c> and <c>SavePreferences</c> fall back to this encoding when the persisted name is
+    /// unusable, so it has to be an offered entry — otherwise the dropdown shows no selection and OK
+    /// rewrites the preference to something that was never on the list.
+    /// </summary>
+    [Test]
+    public void GetAvailableEncodings_OffersTheFallbackEncoding ()
+    {
+        var encodings = SettingsDialog.GetAvailableEncodings();
+
+        Assert.That(encodings, Does.Contain(SettingsDialog.FallbackEncoding));
+    }
+
+    /// <summary>
+    /// The same round trip against a real <see cref="ComboBox"/>, because the reselect goes through
+    /// <c>Items.IndexOf</c> — WinForms, not NUnit, has the final say on whether a row is reachable.
+    /// </summary>
+    [Test]
+    [Apartment(ApartmentState.STA)]
+    public void ComboBox_EveryOfferedRow_IsSelectedAgainAfterASaveAndRestore ()
+    {
+        var encodings = SettingsDialog.GetAvailableEncodings();
+
+        using var comboBox = new ComboBox { FormattingEnabled = true };
+        comboBox.Items.AddRange([.. encodings]);
+
+        Assert.Multiple(() =>
+        {
+            for (var row = 0; row < encodings.Count; row++)
+            {
+                comboBox.SelectedIndex = row;
+                var saved = ((Encoding)comboBox.SelectedItem).HeaderName;
+
+                comboBox.SelectedIndex = -1;
+                comboBox.SelectedItem = EncodingRegistry.GetEncoding(saved, SettingsDialog.FallbackEncoding);
+
+                Assert.That(comboBox.SelectedIndex, Is.EqualTo(row), $"row {row} ('{saved}') is unreachable after a restart");
+            }
+        });
+    }
 }

--- a/src/LogExpert.Tests/Dialogs/SettingsDialogEncodingListTests.cs
+++ b/src/LogExpert.Tests/Dialogs/SettingsDialogEncodingListTests.cs
@@ -26,7 +26,8 @@ public class SettingsDialogEncodingListTests
 
     /// <summary>
     /// Every offered encoding is saved as its name and resolved from that name on the next start, so a
-    /// name that cannot be resolved again would silently degrade to <see cref="Encoding.Default"/>.
+    /// name that cannot be resolved again would silently degrade to
+    /// <see cref="SettingsDialog.FallbackEncoding"/>.
     /// </summary>
     [Test]
     public void GetAvailableEncodings_EveryEntryResolvesByItsPersistedName ()
@@ -97,12 +98,15 @@ public class SettingsDialogEncodingListTests
     }
 
     /// <summary>
-    /// The same round trip against a real <see cref="ComboBox"/>, because the reselect goes through
-    /// <c>Items.IndexOf</c> — WinForms, not NUnit, has the final say on whether a row is reachable.
+    /// The same round trip against a real <see cref="ComboBox"/>, because the reselect actually goes
+    /// through <c>Items.IndexOf</c> — WinForms, not NUnit, has the final say on whether a row is
+    /// reachable. Deliberately kept alongside the assertion above rather than replacing it: this one
+    /// needs an STA apartment and a WinForms control, and the invariant should still be pinned where
+    /// that is unavailable.
     /// </summary>
     [Test]
     [Apartment(ApartmentState.STA)]
-    public void ComboBox_EveryOfferedRow_IsSelectedAgainAfterASaveAndRestore ()
+    public void GetAvailableEncodings_EveryOfferedRowIsReselectableInARealComboBox ()
     {
         var encodings = SettingsDialog.GetAvailableEncodings();
 

--- a/src/LogExpert.UI/Dialogs/SettingsDialog.cs
+++ b/src/LogExpert.UI/Dialogs/SettingsDialog.cs
@@ -280,7 +280,7 @@ internal partial class SettingsDialog : Form
         FillReaderTypeList();
         FillControlCharsTab();
 
-        comboBoxEncoding.SelectedItem = EncodingRegistry.GetEncoding(Preferences.DefaultEncoding, Encoding.Default);
+        comboBoxEncoding.SelectedItem = EncodingRegistry.GetEncoding(Preferences.DefaultEncoding, FallbackEncoding);
         comboBoxLanguage.SelectedItem = CultureInfo.GetCultureInfo(Preferences.DefaultLanguage).Name;
 
         switch (Preferences.ColumnizerSelectionPriority)
@@ -704,20 +704,30 @@ internal partial class SettingsDialog : Form
     }
 
     /// <summary>
-    /// The encodings offered as the default encoding: ASCII, Default (UTF-8), ISO-8859-1, UTF-8,
-    /// Unicode, Windows-1250 and Windows-1252.
+    /// The entry the dialog falls back to when the persisted name is unusable — on both the way in
+    /// (nothing to select) and the way out (nothing selected). Has to be one of
+    /// <see cref="GetAvailableEncodings"/>, otherwise the combo box shows a blank selection and OK writes
+    /// back a value the list never offered.
+    /// </summary>
+    internal static Encoding FallbackEncoding { get; } = Encoding.UTF8;
+
+    /// <summary>
+    /// The encodings offered as the default encoding: ASCII, ISO-8859-1, UTF-8, Unicode, Windows-1250
+    /// and Windows-1252.
     /// </summary>
     /// <remarks>
     /// Separate from <see cref="FillEncodingList"/> so the offered set can be asserted without building
-    /// the dialog. The selected entry is saved by name, so every entry has to be resolvable by name on
-    /// the next start — which is why the code pages go through <see cref="EncodingRegistry"/>.
+    /// the dialog. The selected entry is saved by name and reselected by equality on the next start, so
+    /// every entry has to be resolvable by name (which is why the code pages go through
+    /// <see cref="EncodingRegistry"/>) and no two entries may share a code page — <c>Encoding.Default</c>
+    /// is deliberately absent because it is code page 65001 just like <see cref="Encoding.UTF8"/>,
+    /// differing only in the BOM it emits, which a read-side default encoding never uses.
     /// </remarks>
     internal static IReadOnlyList<Encoding> GetAvailableEncodings ()
     {
         return
         [
             Encoding.ASCII,
-            Encoding.Default,
             Encoding.Latin1,
             Encoding.UTF8,
             Encoding.Unicode,
@@ -823,7 +833,7 @@ internal partial class SettingsDialog : Form
         Preferences.LinesPerBuffer = (int)upDownLinesPerBlock.Value;
         Preferences.PollingInterval = (int)upDownPollingInterval.Value;
         Preferences.MultiThreadFilter = checkBoxMultiThread.Checked;
-        Preferences.DefaultEncoding = comboBoxEncoding.SelectedItem != null ? (comboBoxEncoding.SelectedItem as Encoding).HeaderName : Encoding.Default.HeaderName;
+        Preferences.DefaultEncoding = comboBoxEncoding.SelectedItem != null ? (comboBoxEncoding.SelectedItem as Encoding).HeaderName : FallbackEncoding.HeaderName;
         Preferences.DefaultLanguage = comboBoxLanguage.SelectedItem != null ? (comboBoxLanguage.SelectedItem as string) : CultureInfo.GetCultureInfo("en-US").Name;
         Preferences.ShowColumnFinder = checkBoxColumnFinder.Checked;
         Preferences.ReaderType = comboBoxReaderType.SelectedItem != null ? (ReaderType)comboBoxReaderType.SelectedItem : ReaderType.SystemDirect;

--- a/src/LogExpert.UI/Dialogs/SettingsDialog.cs
+++ b/src/LogExpert.UI/Dialogs/SettingsDialog.cs
@@ -121,6 +121,14 @@ internal partial class SettingsDialog : Form
 
     private IConfigManager ConfigManager { get; }
 
+    /// <summary>
+    /// The encoding the dialog falls back to when the persisted name is unusable — on both the way in
+    /// (nothing to select) and the way out (nothing selected). Has to be one of
+    /// <see cref="GetAvailableEncodings"/>, otherwise the combo box shows a blank selection and OK writes
+    /// back a value the list never offered.
+    /// </summary>
+    internal static Encoding FallbackEncoding { get; } = Encoding.UTF8;
+
     #endregion
 
     #region Private Methods
@@ -704,14 +712,6 @@ internal partial class SettingsDialog : Form
     }
 
     /// <summary>
-    /// The entry the dialog falls back to when the persisted name is unusable — on both the way in
-    /// (nothing to select) and the way out (nothing selected). Has to be one of
-    /// <see cref="GetAvailableEncodings"/>, otherwise the combo box shows a blank selection and OK writes
-    /// back a value the list never offered.
-    /// </summary>
-    internal static Encoding FallbackEncoding { get; } = Encoding.UTF8;
-
-    /// <summary>
     /// The encodings offered as the default encoding: ASCII, ISO-8859-1, UTF-8, Unicode, Windows-1250
     /// and Windows-1252.
     /// </summary>
@@ -833,7 +833,7 @@ internal partial class SettingsDialog : Form
         Preferences.LinesPerBuffer = (int)upDownLinesPerBlock.Value;
         Preferences.PollingInterval = (int)upDownPollingInterval.Value;
         Preferences.MultiThreadFilter = checkBoxMultiThread.Checked;
-        Preferences.DefaultEncoding = comboBoxEncoding.SelectedItem != null ? (comboBoxEncoding.SelectedItem as Encoding).HeaderName : FallbackEncoding.HeaderName;
+        Preferences.DefaultEncoding = comboBoxEncoding.SelectedItem is Encoding selectedEncoding ? selectedEncoding.HeaderName : FallbackEncoding.HeaderName;
         Preferences.DefaultLanguage = comboBoxLanguage.SelectedItem != null ? (comboBoxLanguage.SelectedItem as string) : CultureInfo.GetCultureInfo("en-US").Name;
         Preferences.ShowColumnFinder = checkBoxColumnFinder.Checked;
         Preferences.ReaderType = comboBoxReaderType.SelectedItem != null ? (ReaderType)comboBoxReaderType.SelectedItem : ReaderType.SystemDirect;


### PR DESCRIPTION
fix: make every Preferences encoding row reselectable
The Default encoding dropdown offered both Encoding.Default and
Encoding.UTF8. On .NET both are code page 65001 with HeaderName
"utf-8", differing only in the BOM they emit, so the list showed two
rows the user could not tell apart.

The selection is persisted by HeaderName and restored by equality, and
Encoding.GetEncoding("utf-8") always yields Encoding.UTF8. Picking the
Encoding.Default row therefore silently became UTF-8-with-BOM on the
next start, and that row could never be selected again.

Drop Encoding.Default from the list. The distinction was never
meaningful for this setting: the default encoding only applies when
reading a file with no BOM, where emitting a preamble is irrelevant.
The "no encoding configured" case stays covered by DetermineEncoding's
fallback chain. Saved preferences need no migration — both rows already
persisted as "utf-8", which now names exactly one row.

Route the dialog's in and out fallbacks through a named
FallbackEncoding so the fallback is provably an offered entry.