### PR TITLE
Fix: "Text filter" save on exit

### DIFF
--- a/src/LogExpert.UI/Controls/LogWindow/LogWindow.cs
+++ b/src/LogExpert.UI/Controls/LogWindow/LogWindow.cs
@@ -5893,10 +5893,8 @@ internal partial class LogWindow : DockContent, ILogPaintContextUI, ILogView, IL
 
         if (Preferences.SaveFilters)
         {
-            //when a filter is added, its added to the Configmanager.Settings.FilterList and not to the _filterParams, this is probably an oversight and maybe a bug
-            //but for the consistency the FilterList should be saved as whole for every file
-            snapshot.FilterParamsList = [.. ConfigManager.Settings.FilterList];
-
+			// Persist this window's active filter; FilterList contains global saved presets.
+			snapshot.FilterParamsList = [_filterParams.Clone()];
             foreach (var filterPipe in _filterPipeList)
             {
                 snapshot.FilterTabs.Add(new FilterTabSnapshot


### PR DESCRIPTION
On exit, Logexpert should store in .lxp file variable "SearchText" with last used value from "Text filter". But when exiting, the value "IMPORT_TEST_FILTER" was stored instead. This propose change fixes that. In this change, last filter used is properly saved and loaded on app start.
Before:
<img width="385" height="80" alt="image" src="https://github.com/user-attachments/assets/e8fa7a79-505d-4594-aba3-c5a1db0bd76c" />
<img width="329" height="61" alt="image" src="https://github.com/user-attachments/assets/1db77479-8e1a-468a-81e6-4d4d1ca3c0a2" />
After:
<img width="252" height="59" alt="image" src="https://github.com/user-attachments/assets/a50953da-6be2-4be6-9373-f8856c7feac4" />

