### PR TITLE
Fix: Open tabs order on next start

### DIFF
--- a/src/LogExpert.UI/Services/TabControllerService/TabController.cs
+++ b/src/LogExpert.UI/Services/TabControllerService/TabController.cs
@@ -458,15 +458,16 @@ internal class TabController : ITabController
     /// Gets all LogWindow instances from the DockPanel's Contents collection.
     /// </summary>
     /// <returns>Read-only list of all LogWindows in the DockPanel</returns>
-    public IReadOnlyList<LogWindow> GetAllWindowsFromDockPanel ()
-    {
-        return !_initialized || _dockPanel == null
-            ? []
-            : (IReadOnlyList<LogWindow>)_dockPanel.Contents
-            .OfType<LogWindow>()
-            .ToList()
-            .AsReadOnly();
-    }
+	public IReadOnlyList<LogWindow> GetAllWindowsFromDockPanel ()
+	{
+		return !_initialized || _dockPanel == null
+			? []
+			: _dockPanel.Panes
+				.Where(pane => pane.DockState == DockState.Document)
+				.SelectMany(pane => pane.Contents.OfType<LogWindow>())
+				.ToList()
+				.AsReadOnly();
+	}
 
     #endregion
 }


### PR DESCRIPTION
LogExpert does not remember open tabs order from last instance. When app starts, tabs are restored in different order from last state. This change should fix mentioned issue.

### Before proposed change:
Initial tab order:
<img width="486" height="116" alt="image" src="https://github.com/user-attachments/assets/8ecbeaaa-ea1b-4a0f-9565-b4713d5cbf68" />
Tab order after close/open:
<img width="494" height="112" alt="image" src="https://github.com/user-attachments/assets/fe3061bc-137e-407a-9d86-98444222ac50" />


### After proposed change:
Initial tab order:
<img width="491" height="126" alt="image" src="https://github.com/user-attachments/assets/42fdcccb-4e9f-4c0e-8bc1-8ca09d8ef081" />
Tab order after close/open:
<img width="478" height="125" alt="image" src="https://github.com/user-attachments/assets/cfccfae4-22fa-4301-83b4-a23492fe58c9" />

