### PR TITLE
fix: keep floating tabs in GetAllWindowsFromDockPanel

### DIFF
--- a/src/LogExpert.UI/Services/TabControllerService/TabController.cs
+++ b/src/LogExpert.UI/Services/TabControllerService/TabController.cs
@@ -455,19 +455,19 @@ internal class TabController : ITabController
     }
 
     /// <summary>
-    /// Gets all LogWindow instances from the DockPanel's Contents collection.
+    /// Gets all LogWindow instances currently held by the DockPanel's panes, in the order their tab strips display
+    /// them. Panes of every dock state are enumerated, so floating windows are included.
     /// </summary>
     /// <returns>Read-only list of all LogWindows in the DockPanel</returns>
-	public IReadOnlyList<LogWindow> GetAllWindowsFromDockPanel ()
-	{
-		return !_initialized || _dockPanel == null
-			? []
-			: _dockPanel.Panes
-				.Where(pane => pane.DockState == DockState.Document)
-				.SelectMany(pane => pane.Contents.OfType<LogWindow>())
-				.ToList()
-				.AsReadOnly();
-	}
+    public IReadOnlyList<LogWindow> GetAllWindowsFromDockPanel ()
+    {
+        return !_initialized || _dockPanel == null
+            ? []
+            : _dockPanel.Panes
+                .SelectMany(pane => pane.DisplayingContents.OfType<LogWindow>())
+                .ToList()
+                .AsReadOnly();
+    }
 
     #endregion
 }


### PR DESCRIPTION
Follow-up to #685.

That PR fixed the tab restore order by enumerating `DockPanel.Panes` instead of `DockPanel.Contents`, but narrowed the panes to `DockState.Document`. `LogWindow` sets `DockAreas = DockAreas.Document | DockAreas.Float` (`LogTabWindow.AddLogWindow`, line 836), so a floated tab lives in a pane with `DockState.Float` and was dropped from the result. The Developer had not enough time to fix this, because I merged the PR to fast.

Two consumers were affected:

- `FileOperationService.SaveLastOpenFilesList` — a floated tab was not written to `LastOpenFilesList`, so it did not come back on the next start.
- `LogTabWindow.OnSaveSessionToolStripMenuItemClick` — a floated tab was missing from the `.lxj` `FileNames` list, while `TabLayoutXml` still referenced it. On restore `DeserializeDockContent` → `FindWindowForFile` returns null for it and the entry silently disappears.

This drops the dock-state filter, and reads `DisplayingContents` instead of `Contents` — that is the collection the tab strip renders, so it is the more direct expression of "tab order" and it excludes non-displaying contents. In practice the two are equivalent today: no `LogWindow` is ever hidden without being closed, and `LogWindow`'s `DockAreas` rules out auto-hide.

The ordering fix from #685 is unchanged and still works.

### Known limitation, unchanged by this PR

`DockPanel.Panes` is in pane-creation order, not visual left-to-right, so order is correct *within* a pane and arbitrary *across* panes. A split document area still restores in a semi-arbitrary order. Fixing that needs a different source of truth than the pane collection.

### Testing

`LogExpert.UI` builds clean; the 29 `TabControllerTests` pass.

No regression test added: `TabControllerTests` documents that `LogWindow` cannot be instantiated without full UI infrastructure, and `OfType<LogWindow>()` filters out any plain `DockContent` stub, so the floating case is not reachable from that fixture.