### PR TITLE
Add GB2312 encoding, and build both encoding lists from one source

### DIFF
--- a/src/LogExpert.Core/Classes/Log/Streamreaders/PositionAwareStreamReaderBase.cs
+++ b/src/LogExpert.Core/Classes/Log/Streamreaders/PositionAwareStreamReaderBase.cs
@@ -1,4 +1,4 @@
-using System.Text;
+﻿using System.Text;
 
 using LogExpert.Core.Entities;
 
@@ -221,8 +221,19 @@ public abstract class PositionAwareStreamReaderBase : LogStreamReaderBase
         return (0, null);
     }
 
+    /// <summary>
+    /// Bytes to advance the position by per character read, or 0 for "measure the character".
+    /// </summary>
+    /// <remarks>
+    /// The fallback is keyed on <see cref="Encoding.IsSingleByte"/>, not on "everything else is one
+    /// byte": a variable-width code page such as GB2312 (one byte per ASCII character, two per Chinese
+    /// one) is neither a <see cref="UTF8Encoding"/> nor a <see cref="UnicodeEncoding"/>, and counting it
+    /// as one byte per character drifts the position on the first non-ASCII character.
+    /// </remarks>
     public static int GetPosIncPrecomputed (Encoding usedEncoding)
     {
+        ArgumentNullException.ThrowIfNull(usedEncoding);
+
         switch (usedEncoding)
         {
             case UTF8Encoding:
@@ -235,7 +246,7 @@ public abstract class PositionAwareStreamReaderBase : LogStreamReaderBase
                 }
             default:
                 {
-                    return 1;
+                    return usedEncoding.IsSingleByte ? 1 : 0;
                 }
         }
     }

--- a/src/LogExpert.Core/Helpers/EncodingRegistry.cs
+++ b/src/LogExpert.Core/Helpers/EncodingRegistry.cs
@@ -30,13 +30,54 @@ public static class EncodingRegistry
     /// <summary>
     /// Code page of GB2312, the simplified-Chinese code page (issue #688).
     /// </summary>
-    /// <remarks>
-    /// Named — unlike the code pages that appear once, as a bare number, at the single place that
-    /// offers them — because three call sites have to agree on it: the Preferences default-encoding
-    /// list, the encoding menu row that applies it, and the check-state lookup that has to recognise a
-    /// file already being read with it.
-    /// </remarks>
     public const int CODE_PAGE_GB2312 = 936;
+
+    /// <summary>
+    /// The encodings LogExpert offers the user to choose from, in the order they are presented.
+    /// </summary>
+    /// <remarks>
+    /// The single list: the Preferences default-encoding combo box and the per-file View → Encoding
+    /// menu both draw their rows from it, so they cannot drift apart and adding an encoding is a
+    /// one-line change here. Three invariants, each pinned by a test:
+    /// <list type="bullet">
+    ///   <item>
+    ///     Every entry resolves from its own <see cref="Encoding.HeaderName"/>, because that name is
+    ///     what gets persisted (in the settings JSON and in a .lxp) and resolved again on the next
+    ///     start. An entry that did not would silently degrade to a fallback.
+    ///   </item>
+    ///   <item>
+    ///     No two entries share a code page. Both UIs label a row with its header name, so two entries
+    ///     for one code page are two rows the user cannot tell apart — which is exactly what
+    ///     <c>Encoding.Default</c> alongside <see cref="Encoding.UTF8"/> produced (both are code page
+    ///     65001 on .NET, differing only in the BOM they emit, which a read-side encoding never uses).
+    ///     Hence no <c>Encoding.Default</c> entry.
+    ///   </item>
+    ///   <item>
+    ///     New entries are appended rather than sorted in, so an existing user's row does not move
+    ///     under the cursor on upgrade.
+    ///   </item>
+    /// </list>
+    /// </remarks>
+    public static IReadOnlyList<Encoding> OfferedEncodings => _offeredEncodings.Value;
+
+    /// <remarks>
+    /// Built once: <see cref="Encoding"/> instances are immutable and the ones from
+    /// <see cref="GetEncoding(int)"/> are cached by .NET anyway, so the list is safe to share. Lazy
+    /// rather than a plain initialiser so the code pages resolve through
+    /// <see cref="EnsureRegistered"/> rather than depending on when this class is first touched.
+    /// </remarks>
+    private static readonly Lazy<IReadOnlyList<Encoding>> _offeredEncodings = new(
+        () =>
+        [
+            Encoding.ASCII,
+            Encoding.Latin1,
+            Encoding.UTF8,
+            Encoding.Unicode,
+            GetEncoding(1250),
+            GetEncoding(1252),
+            GetEncoding(CODE_PAGE_GB2312)
+        ],
+        LazyThreadSafetyMode.ExecutionAndPublication);
 
     /// <summary>
     /// Registers <see cref="CodePagesEncodingProvider"/> on first use.

--- a/src/LogExpert.Core/Helpers/EncodingRegistry.cs
+++ b/src/LogExpert.Core/Helpers/EncodingRegistry.cs
@@ -28,6 +28,17 @@ namespace LogExpert.Core.Helpers;
 public static class EncodingRegistry
 {
     /// <summary>
+    /// Code page of GB2312, the simplified-Chinese code page (issue #688).
+    /// </summary>
+    /// <remarks>
+    /// Named — unlike the code pages that appear once, as a bare number, at the single place that
+    /// offers them — because three call sites have to agree on it: the Preferences default-encoding
+    /// list, the encoding menu row that applies it, and the check-state lookup that has to recognise a
+    /// file already being read with it.
+    /// </remarks>
+    public const int CODE_PAGE_GB2312 = 936;
+
+    /// <summary>
     /// Registers <see cref="CodePagesEncodingProvider"/> on first use.
     /// </summary>
     /// <remarks>

--- a/src/LogExpert.Resources/Resources.Designer.cs
+++ b/src/LogExpert.Resources/Resources.Designer.cs
@@ -2285,20 +2285,20 @@ namespace LogExpert {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ANSI.
-        /// </summary>
-        public static string LogTabWindow_UI_ToolStripMenuItem_encodingANSIToolStripMenuItem {
-            get {
-                return ResourceManager.GetString("LogTabWindow_UI_ToolStripMenuItem_encodingANSIToolStripMenuItem", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to ASCII.
         /// </summary>
         public static string LogTabWindow_UI_ToolStripMenuItem_encodingASCIIToolStripMenuItem {
             get {
                 return ResourceManager.GetString("LogTabWindow_UI_ToolStripMenuItem_encodingASCIIToolStripMenuItem", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to GB2312.
+        /// </summary>
+        public static string LogTabWindow_UI_ToolStripMenuItem_encodingGB2312toolStripMenuItem {
+            get {
+                return ResourceManager.GetString("LogTabWindow_UI_ToolStripMenuItem_encodingGB2312toolStripMenuItem", resourceCulture);
             }
         }
         

--- a/src/LogExpert.Resources/Resources.Designer.cs
+++ b/src/LogExpert.Resources/Resources.Designer.cs
@@ -2285,56 +2285,11 @@ namespace LogExpert {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ASCII.
-        /// </summary>
-        public static string LogTabWindow_UI_ToolStripMenuItem_encodingASCIIToolStripMenuItem {
-            get {
-                return ResourceManager.GetString("LogTabWindow_UI_ToolStripMenuItem_encodingASCIIToolStripMenuItem", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to GB2312.
-        /// </summary>
-        public static string LogTabWindow_UI_ToolStripMenuItem_encodingGB2312toolStripMenuItem {
-            get {
-                return ResourceManager.GetString("LogTabWindow_UI_ToolStripMenuItem_encodingGB2312toolStripMenuItem", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to ISO-8859-1.
-        /// </summary>
-        public static string LogTabWindow_UI_ToolStripMenuItem_encodingISO88591toolStripMenuItem {
-            get {
-                return ResourceManager.GetString("LogTabWindow_UI_ToolStripMenuItem_encodingISO88591toolStripMenuItem", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Encoding.
         /// </summary>
         public static string LogTabWindow_UI_ToolStripMenuItem_encodingToolStripMenuItem {
             get {
                 return ResourceManager.GetString("LogTabWindow_UI_ToolStripMenuItem_encodingToolStripMenuItem", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Unicode.
-        /// </summary>
-        public static string LogTabWindow_UI_ToolStripMenuItem_encodingUTF16toolStripMenuItem {
-            get {
-                return ResourceManager.GetString("LogTabWindow_UI_ToolStripMenuItem_encodingUTF16toolStripMenuItem", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to UTF8.
-        /// </summary>
-        public static string LogTabWindow_UI_ToolStripMenuItem_encodingUTF8toolStripMenuItem {
-            get {
-                return ResourceManager.GetString("LogTabWindow_UI_ToolStripMenuItem_encodingUTF8toolStripMenuItem", resourceCulture);
             }
         }
         

--- a/src/LogExpert.Resources/Resources.de.resx
+++ b/src/LogExpert.Resources/Resources.de.resx
@@ -1324,21 +1324,6 @@ Ein ausgewähltes Tool erscheint in der Iconbar. Alle anderen verfügbaren Tools
   <data name="LogTabWindow_UI_ToolStripMenuItem_encodingToolStripMenuItem" xml:space="preserve">
 		<value>Encoding</value>
 	</data>
-  <data name="LogTabWindow_UI_ToolStripMenuItem_encodingASCIIToolStripMenuItem" xml:space="preserve">
-		<value>ASCII</value>
-	</data>
-  <data name="LogTabWindow_UI_ToolStripMenuItem_encodingISO88591toolStripMenuItem" xml:space="preserve">
-		<value>ISO-8859-1</value>
-	</data>
-  <data name="LogTabWindow_UI_ToolStripMenuItem_encodingUTF8toolStripMenuItem" xml:space="preserve">
-		<value>UTF8</value>
-	</data>
-  <data name="LogTabWindow_UI_ToolStripMenuItem_encodingUTF16toolStripMenuItem" xml:space="preserve">
-		<value>Unicode</value>
-	</data>
-  <data name="LogTabWindow_UI_ToolStripMenuItem_encodingGB2312toolStripMenuItem" xml:space="preserve">
-		<value>GB2312</value>
-	</data>
   <data name="LogTabWindow_UI_ToolStripTextBox_timeshiftToolStripTextBox" xml:space="preserve">
 		<value>+00:00:00.000</value>
 	</data>

--- a/src/LogExpert.Resources/Resources.de.resx
+++ b/src/LogExpert.Resources/Resources.de.resx
@@ -1327,9 +1327,6 @@ Ein ausgewähltes Tool erscheint in der Iconbar. Alle anderen verfügbaren Tools
   <data name="LogTabWindow_UI_ToolStripMenuItem_encodingASCIIToolStripMenuItem" xml:space="preserve">
 		<value>ASCII</value>
 	</data>
-  <data name="LogTabWindow_UI_ToolStripMenuItem_encodingANSIToolStripMenuItem" xml:space="preserve">
-		<value>ANSI</value>
-	</data>
   <data name="LogTabWindow_UI_ToolStripMenuItem_encodingISO88591toolStripMenuItem" xml:space="preserve">
 		<value>ISO-8859-1</value>
 	</data>
@@ -1338,6 +1335,9 @@ Ein ausgewähltes Tool erscheint in der Iconbar. Alle anderen verfügbaren Tools
 	</data>
   <data name="LogTabWindow_UI_ToolStripMenuItem_encodingUTF16toolStripMenuItem" xml:space="preserve">
 		<value>Unicode</value>
+	</data>
+  <data name="LogTabWindow_UI_ToolStripMenuItem_encodingGB2312toolStripMenuItem" xml:space="preserve">
+		<value>GB2312</value>
 	</data>
   <data name="LogTabWindow_UI_ToolStripTextBox_timeshiftToolStripTextBox" xml:space="preserve">
 		<value>+00:00:00.000</value>

--- a/src/LogExpert.Resources/Resources.resx
+++ b/src/LogExpert.Resources/Resources.resx
@@ -1350,9 +1350,6 @@ Checked tools will appear in the icon bar. All other tools are available in the 
   <data name="LogTabWindow_UI_ToolStripMenuItem_encodingASCIIToolStripMenuItem" xml:space="preserve">
         <value>ASCII</value>
     </data>
-  <data name="LogTabWindow_UI_ToolStripMenuItem_encodingANSIToolStripMenuItem" xml:space="preserve">
-        <value>ANSI</value>
-    </data>
   <data name="LogTabWindow_UI_ToolStripMenuItem_encodingISO88591toolStripMenuItem" xml:space="preserve">
         <value>ISO-8859-1</value>
     </data>
@@ -1361,6 +1358,9 @@ Checked tools will appear in the icon bar. All other tools are available in the 
     </data>
   <data name="LogTabWindow_UI_ToolStripMenuItem_encodingUTF16toolStripMenuItem" xml:space="preserve">
         <value>Unicode</value>
+    </data>
+  <data name="LogTabWindow_UI_ToolStripMenuItem_encodingGB2312toolStripMenuItem" xml:space="preserve">
+        <value>GB2312</value>
     </data>
   <data name="LogTabWindow_UI_ToolStripTextBox_timeshiftToolStripTextBox" xml:space="preserve">
         <value>+00:00:00.000</value>

--- a/src/LogExpert.Resources/Resources.resx
+++ b/src/LogExpert.Resources/Resources.resx
@@ -1347,21 +1347,6 @@ Checked tools will appear in the icon bar. All other tools are available in the 
   <data name="LogTabWindow_UI_ToolStripMenuItem_encodingToolStripMenuItem" xml:space="preserve">
         <value>Encoding</value>
     </data>
-  <data name="LogTabWindow_UI_ToolStripMenuItem_encodingASCIIToolStripMenuItem" xml:space="preserve">
-        <value>ASCII</value>
-    </data>
-  <data name="LogTabWindow_UI_ToolStripMenuItem_encodingISO88591toolStripMenuItem" xml:space="preserve">
-        <value>ISO-8859-1</value>
-    </data>
-  <data name="LogTabWindow_UI_ToolStripMenuItem_encodingUTF8toolStripMenuItem" xml:space="preserve">
-        <value>UTF8</value>
-    </data>
-  <data name="LogTabWindow_UI_ToolStripMenuItem_encodingUTF16toolStripMenuItem" xml:space="preserve">
-        <value>Unicode</value>
-    </data>
-  <data name="LogTabWindow_UI_ToolStripMenuItem_encodingGB2312toolStripMenuItem" xml:space="preserve">
-        <value>GB2312</value>
-    </data>
   <data name="LogTabWindow_UI_ToolStripTextBox_timeshiftToolStripTextBox" xml:space="preserve">
         <value>+00:00:00.000</value>
     </data>

--- a/src/LogExpert.Resources/Resources.zh-CN.resx
+++ b/src/LogExpert.Resources/Resources.zh-CN.resx
@@ -1966,21 +1966,6 @@ YY[YY] = 年
   <data name="LogTabWindow_UI_MenuStrip_mainMenuStrip" xml:space="preserve">
     <value>菜单条1</value>
   </data>
-  <data name="LogTabWindow_UI_ToolStripMenuItem_encodingASCIIToolStripMenuItem" xml:space="preserve">
-    <value>ASCII码</value>
-  </data>
-  <data name="LogTabWindow_UI_ToolStripMenuItem_encodingISO88591toolStripMenuItem" xml:space="preserve">
-    <value>ISO-8859-1</value>
-  </data>
-  <data name="LogTabWindow_UI_ToolStripMenuItem_encodingUTF8toolStripMenuItem" xml:space="preserve">
-    <value>UTF8</value>
-  </data>
-  <data name="LogTabWindow_UI_ToolStripMenuItem_encodingUTF16toolStripMenuItem" xml:space="preserve">
-    <value>统一码</value>
-  </data>
-  <data name="LogTabWindow_UI_ToolStripMenuItem_encodingGB2312toolStripMenuItem" xml:space="preserve">
-    <value>GB2312</value>
-  </data>
   <data name="LogTabWindow_UI_ToolStripTextBox_timeshiftToolStripTextBox" xml:space="preserve">
     <value>+00:00:00.000</value>
   </data>

--- a/src/LogExpert.Resources/Resources.zh-CN.resx
+++ b/src/LogExpert.Resources/Resources.zh-CN.resx
@@ -1969,9 +1969,6 @@ YY[YY] = 年
   <data name="LogTabWindow_UI_ToolStripMenuItem_encodingASCIIToolStripMenuItem" xml:space="preserve">
     <value>ASCII码</value>
   </data>
-  <data name="LogTabWindow_UI_ToolStripMenuItem_encodingANSIToolStripMenuItem" xml:space="preserve">
-    <value>美国国家标准协会</value>
-  </data>
   <data name="LogTabWindow_UI_ToolStripMenuItem_encodingISO88591toolStripMenuItem" xml:space="preserve">
     <value>ISO-8859-1</value>
   </data>
@@ -1980,6 +1977,9 @@ YY[YY] = 年
   </data>
   <data name="LogTabWindow_UI_ToolStripMenuItem_encodingUTF16toolStripMenuItem" xml:space="preserve">
     <value>统一码</value>
+  </data>
+  <data name="LogTabWindow_UI_ToolStripMenuItem_encodingGB2312toolStripMenuItem" xml:space="preserve">
+    <value>GB2312</value>
   </data>
   <data name="LogTabWindow_UI_ToolStripTextBox_timeshiftToolStripTextBox" xml:space="preserve">
     <value>+00:00:00.000</value>

--- a/src/LogExpert.Tests/Dialogs/SettingsDialogEncodingListTests.cs
+++ b/src/LogExpert.Tests/Dialogs/SettingsDialogEncodingListTests.cs
@@ -8,110 +8,28 @@ using NUnit.Framework;
 namespace LogExpert.Tests.Dialogs;
 
 /// <summary>
-/// The Preferences encoding dropdown is the only way to set <c>Preferences.DefaultEncoding</c>, so the
-/// list is asserted directly — building the dialog is not needed to know what it offers.
+/// The Preferences encoding combo box, which is the only way to set <c>Preferences.DefaultEncoding</c>.
+/// What it offers is <see cref="EncodingRegistry.OfferedEncodings"/> and is asserted in
+/// <c>OfferedEncodingsTests</c>; what is left here is the part only a real
+/// <see cref="ComboBox"/> can answer.
 /// </summary>
 [TestFixture]
 public class SettingsDialogEncodingListTests
 {
-    [Test]
-    [TestCase(1250, TestName = "GetAvailableEncodings_OffersWindows1250")]
-    [TestCase(1252, TestName = "GetAvailableEncodings_OffersWindows1252")]
-    [TestCase(936, TestName = "GetAvailableEncodings_OffersGb2312")]
-    public void GetAvailableEncodings_OffersLegacyCodePage (int codePage)
-    {
-        var encodings = SettingsDialog.GetAvailableEncodings();
-
-        Assert.That(encodings.Select(encoding => encoding.CodePage), Does.Contain(codePage));
-    }
-
     /// <summary>
-    /// Every offered encoding is saved as its name and resolved from that name on the next start, so a
-    /// name that cannot be resolved again would silently degrade to
-    /// <see cref="SettingsDialog.FallbackEncoding"/>.
-    /// </summary>
-    [Test]
-    public void GetAvailableEncodings_EveryEntryResolvesByItsPersistedName ()
-    {
-        var encodings = SettingsDialog.GetAvailableEncodings();
-
-        Assert.Multiple(() =>
-        {
-            foreach (var encoding in encodings)
-            {
-                Assert.That(
-                    EncodingRegistry.TryGetEncoding(encoding.HeaderName, out _),
-                    Is.True,
-                    $"'{encoding.HeaderName}' cannot be resolved back from a saved preference");
-            }
-        });
-    }
-
-    /// <summary>
-    /// The dropdown renders each entry as its <see cref="Encoding.HeaderName"/>, so two entries sharing a
-    /// code page are two rows the user cannot tell apart. <c>Encoding.Default</c> and
-    /// <see cref="Encoding.UTF8"/> are both code page 65001 on .NET and both read <c>utf-8</c>.
-    /// </summary>
-    [Test]
-    public void GetAvailableEncodings_NoTwoEntriesShareACodePage ()
-    {
-        var codePages = SettingsDialog.GetAvailableEncodings().Select(encoding => encoding.CodePage);
-
-        Assert.That(codePages, Is.Unique);
-    }
-
-    /// <summary>
-    /// The selection is persisted by name and restored with
-    /// <c>comboBoxEncoding.SelectedItem = EncodingRegistry.GetEncoding(name, …)</c>. WinForms locates that
-    /// item with <see cref="object.Equals(object)"/>, so an entry whose name resolves back to an instance
-    /// that is not equal to it can never be reselected — the row goes dead after the first restart.
-    /// </summary>
-    [Test]
-    public void GetAvailableEncodings_EveryEntryIsReselectableAfterARoundTrip ()
-    {
-        var encodings = SettingsDialog.GetAvailableEncodings();
-
-        Assert.Multiple(() =>
-        {
-            foreach (var encoding in encodings)
-            {
-                var restored = EncodingRegistry.GetEncoding(encoding.HeaderName, SettingsDialog.FallbackEncoding);
-
-                Assert.That(
-                    restored,
-                    Is.EqualTo(encoding),
-                    $"picking '{encoding.HeaderName}' saves a name that reselects a different entry");
-            }
-        });
-    }
-
-    /// <summary>
-    /// <c>FillDialog</c> and <c>SavePreferences</c> fall back to this encoding when the persisted name is
-    /// unusable, so it has to be an offered entry — otherwise the dropdown shows no selection and OK
-    /// rewrites the preference to something that was never on the list.
-    /// </summary>
-    [Test]
-    public void GetAvailableEncodings_OffersTheFallbackEncoding ()
-    {
-        var encodings = SettingsDialog.GetAvailableEncodings();
-
-        Assert.That(encodings, Does.Contain(SettingsDialog.FallbackEncoding));
-    }
-
-    /// <summary>
-    /// The same round trip against a real <see cref="ComboBox"/>, because the reselect actually goes
-    /// through <c>Items.IndexOf</c> — WinForms, not NUnit, has the final say on whether a row is
-    /// reachable. Deliberately kept alongside the assertion above rather than replacing it: this one
-    /// needs an STA apartment and a WinForms control, and the invariant should still be pinned where
-    /// that is unavailable.
+    /// The persist/restore round trip against a real <see cref="ComboBox"/>, configured the way the
+    /// dialog configures it: the reselect goes through <c>Items.IndexOf</c>, and WinForms — not NUnit —
+    /// has the final say on whether a row is reachable. Deliberately kept alongside the plain assertion
+    /// in <c>OfferedEncodingsTests</c> rather than replacing it: this one needs an STA apartment and a
+    /// WinForms control, and the invariant should still be pinned where that is unavailable.
     /// </summary>
     [Test]
     [Apartment(ApartmentState.STA)]
-    public void GetAvailableEncodings_EveryOfferedRowIsReselectableInARealComboBox ()
+    public void EncodingComboBox_EveryOfferedRowIsReselectableAfterARestart ()
     {
-        var encodings = SettingsDialog.GetAvailableEncodings();
+        var encodings = EncodingRegistry.OfferedEncodings;
 
-        using var comboBox = new ComboBox { FormattingEnabled = true };
+        using var comboBox = new ComboBox { DropDownStyle = ComboBoxStyle.DropDownList, FormattingEnabled = true };
         comboBox.Items.AddRange([.. encodings]);
 
         Assert.Multiple(() =>
@@ -125,6 +43,29 @@ public class SettingsDialogEncodingListTests
                 comboBox.SelectedItem = EncodingRegistry.GetEncoding(saved, SettingsDialog.FallbackEncoding);
 
                 Assert.That(comboBox.SelectedIndex, Is.EqualTo(row), $"row {row} ('{saved}') is unreachable after a restart");
+            }
+        });
+    }
+
+    /// <summary>
+    /// The combo box has no <c>DisplayMember</c> — the dialog only sets <c>ValueMember</c>, and WinForms
+    /// falls back to it for the display text. Pinned because without that fallback every row would render
+    /// as <c>Encoding.ToString()</c>, i.e. a .NET type name, and the rows the user picks between would be
+    /// indistinguishable for a different reason than the one issue #688 reported.
+    /// </summary>
+    [Test]
+    [Apartment(ApartmentState.STA)]
+    public void EncodingComboBox_RendersEachRowAsItsHeaderName ()
+    {
+        using var comboBox = new ComboBox { DropDownStyle = ComboBoxStyle.DropDownList, FormattingEnabled = true };
+        comboBox.ValueMember = "HeaderName";
+        comboBox.Items.AddRange([.. EncodingRegistry.OfferedEncodings]);
+
+        Assert.Multiple(() =>
+        {
+            foreach (Encoding encoding in comboBox.Items)
+            {
+                Assert.That(comboBox.GetItemText(encoding), Is.EqualTo(encoding.HeaderName));
             }
         });
     }

--- a/src/LogExpert.Tests/Dialogs/SettingsDialogEncodingListTests.cs
+++ b/src/LogExpert.Tests/Dialogs/SettingsDialogEncodingListTests.cs
@@ -17,6 +17,7 @@ public class SettingsDialogEncodingListTests
     [Test]
     [TestCase(1250, TestName = "GetAvailableEncodings_OffersWindows1250")]
     [TestCase(1252, TestName = "GetAvailableEncodings_OffersWindows1252")]
+    [TestCase(936, TestName = "GetAvailableEncodings_OffersGb2312")]
     public void GetAvailableEncodings_OffersLegacyCodePage (int codePage)
     {
         var encodings = SettingsDialog.GetAvailableEncodings();

--- a/src/LogExpert.Tests/Encodings/EncodingJsonConverterTests.cs
+++ b/src/LogExpert.Tests/Encodings/EncodingJsonConverterTests.cs
@@ -20,6 +20,7 @@ public class EncodingJsonConverterTests
     [Test]
     [TestCase("windows-1250", 1250)]
     [TestCase("windows-1252", 1252)]
+    [TestCase("gb2312", 936)]
     public void ReadJson_LegacyCodePageName_ResolvesInsteadOfFallingBack (string encodingName, int expectedCodePage)
     {
         var encoding = Deserialize($"\"{encodingName}\"");

--- a/src/LogExpert.Tests/Encodings/EncodingRegistryTests.cs
+++ b/src/LogExpert.Tests/Encodings/EncodingRegistryTests.cs
@@ -18,6 +18,7 @@ public class EncodingRegistryTests
     [Test]
     [TestCase(1250)]
     [TestCase(1252)]
+    [TestCase(936)]
     public void GetEncoding_LegacyCodePage_Resolves (int codePage)
     {
         var encoding = EncodingRegistry.GetEncoding(codePage);
@@ -30,6 +31,7 @@ public class EncodingRegistryTests
     [TestCase("windows-1252")]
     [TestCase("utf-8")]
     [TestCase("iso-8859-1")]
+    [TestCase("gb2312")]
     public void TryGetEncoding_SupportedName_ReturnsTrueAndEncoding (string name)
     {
         var resolved = EncodingRegistry.TryGetEncoding(name, out var encoding);

--- a/src/LogExpert.Tests/Encodings/OfferedEncodingsTests.cs
+++ b/src/LogExpert.Tests/Encodings/OfferedEncodingsTests.cs
@@ -1,0 +1,176 @@
+using System.Text;
+
+using LogExpert.Core.Helpers;
+using LogExpert.Dialogs;
+using LogExpert.UI.Services.MenuToolbarService;
+
+using NUnit.Framework;
+
+namespace LogExpert.Tests.Encodings;
+
+/// <summary>
+/// <see cref="EncodingRegistry.OfferedEncodings"/> is the one list of encodings a user can pick: the
+/// Preferences default-encoding combo box and the per-file View → Encoding menu are both built from it.
+/// These tests pin the invariants that list has to hold for either UI to work, so they are asserted once
+/// here rather than per UI.
+/// </summary>
+[TestFixture]
+public class OfferedEncodingsTests
+{
+    [Test]
+    [TestCase(1250, TestName = "OfferedEncodings_OffersWindows1250")]
+    [TestCase(1252, TestName = "OfferedEncodings_OffersWindows1252")]
+    [TestCase(936, TestName = "OfferedEncodings_OffersGb2312")]
+    public void OfferedEncodings_OffersLegacyCodePage (int codePage)
+    {
+        Assert.That(EncodingRegistry.OfferedEncodings.Select(encoding => encoding.CodePage), Does.Contain(codePage));
+    }
+
+    /// <summary>
+    /// Every offered encoding is saved as its name and resolved from that name on the next start, so a
+    /// name that cannot be resolved again would silently degrade to a fallback.
+    /// </summary>
+    [Test]
+    public void OfferedEncodings_EveryEntryResolvesByItsPersistedName ()
+    {
+        Assert.Multiple(() =>
+        {
+            foreach (var encoding in EncodingRegistry.OfferedEncodings)
+            {
+                Assert.That(
+                    EncodingRegistry.TryGetEncoding(encoding.HeaderName, out _),
+                    Is.True,
+                    $"'{encoding.HeaderName}' cannot be resolved back from a saved preference");
+            }
+        });
+    }
+
+    /// <summary>
+    /// Both UIs render an entry as its <see cref="Encoding.HeaderName"/>, so two entries sharing a code
+    /// page are two rows the user cannot tell apart. <c>Encoding.Default</c> and
+    /// <see cref="Encoding.UTF8"/> are both code page 65001 on .NET and both read <c>utf-8</c> — the
+    /// duplicate reported in issue #688.
+    /// </summary>
+    [Test]
+    public void OfferedEncodings_NoTwoEntriesShareACodePage ()
+    {
+        Assert.That(EncodingRegistry.OfferedEncodings.Select(encoding => encoding.CodePage), Is.Unique);
+    }
+
+    /// <summary>
+    /// The same, stated as the property the reporter actually saw: no two rows carry the same label.
+    /// </summary>
+    [Test]
+    public void OfferedEncodings_NoTwoEntriesShareAHeaderName ()
+    {
+        Assert.That(EncodingRegistry.OfferedEncodings.Select(encoding => encoding.HeaderName), Is.Unique);
+    }
+
+    /// <summary>
+    /// The list is shared and handed out repeatedly (every Preferences open, every window's encoding
+    /// menu), so it must be a stable snapshot rather than something a caller could append to.
+    /// </summary>
+    [Test]
+    public void OfferedEncodings_IsTheSameListEveryTime ()
+    {
+        Assert.That(EncodingRegistry.OfferedEncodings, Is.SameAs(EncodingRegistry.OfferedEncodings));
+    }
+
+    /// <summary>
+    /// The Preferences selection is persisted by name and restored with
+    /// <c>comboBoxEncoding.SelectedItem = EncodingRegistry.GetEncoding(name, …)</c>. WinForms locates that
+    /// item with <see cref="object.Equals(object)"/>, so an entry whose name resolves back to an instance
+    /// that is not equal to it can never be reselected — the row goes dead after the first restart.
+    /// </summary>
+    [Test]
+    public void OfferedEncodings_EveryEntryIsReselectableAfterARoundTrip ()
+    {
+        Assert.Multiple(() =>
+        {
+            foreach (var encoding in EncodingRegistry.OfferedEncodings)
+            {
+                var restored = EncodingRegistry.GetEncoding(encoding.HeaderName, SettingsDialog.FallbackEncoding);
+
+                Assert.That(
+                    restored,
+                    Is.EqualTo(encoding),
+                    $"picking '{encoding.HeaderName}' saves a name that reselects a different entry");
+            }
+        });
+    }
+
+    /// <summary>
+    /// <c>FillDialog</c> and <c>SavePreferences</c> fall back to this encoding when the persisted name is
+    /// unusable, so it has to be an offered entry — otherwise the dropdown shows no selection and OK
+    /// rewrites the preference to something that was never on the list.
+    /// </summary>
+    [Test]
+    public void OfferedEncodings_OffersTheSettingsDialogFallback ()
+    {
+        Assert.That(EncodingRegistry.OfferedEncodings, Does.Contain(SettingsDialog.FallbackEncoding));
+    }
+
+    /// <summary>
+    /// The point of the shared list: the encoding menu offers exactly what Preferences offers, in the
+    /// same order. Before this, the menu was hand-declared in the designer and had drifted — it lacked
+    /// windows-1250 and windows-1252, and carried an "ANSI" row Preferences did not.
+    /// </summary>
+    [Test]
+    [Apartment(ApartmentState.STA)]
+    public void EncodingMenu_OffersExactlyTheOfferedEncodings ()
+    {
+        using var encodingMenu = new ToolStripMenuItem("Encoding");
+
+        EncodingMenuBuilder.Fill(encodingMenu, (_, _) => { });
+
+        var rows = encodingMenu.DropDownItems.Cast<ToolStripItem>().ToList();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                rows.Select(EncodingMenuBuilder.EncodingOf),
+                Is.EqualTo(EncodingRegistry.OfferedEncodings).AsCollection);
+
+            Assert.That(
+                rows.Select(row => row.Text),
+                Is.EqualTo(EncodingRegistry.OfferedEncodings.Select(encoding => encoding.HeaderName)).AsCollection,
+                "a row is labelled with its encoding's header name, the same text the Preferences combo shows");
+        });
+    }
+
+    /// <summary>
+    /// Filling twice — a second Log Tab Window, or a rebuild — must not stack a second set of rows.
+    /// </summary>
+    [Test]
+    [Apartment(ApartmentState.STA)]
+    public void EncodingMenu_FilledTwice_DoesNotDuplicateRows ()
+    {
+        using var encodingMenu = new ToolStripMenuItem("Encoding");
+
+        EncodingMenuBuilder.Fill(encodingMenu, (_, _) => { });
+        EncodingMenuBuilder.Fill(encodingMenu, (_, _) => { });
+
+        Assert.That(encodingMenu.DropDownItems, Has.Count.EqualTo(EncodingRegistry.OfferedEncodings.Count));
+    }
+
+    /// <summary>
+    /// Clicking a row has to hand the click handler that row's encoding — that is the whole mechanism by
+    /// which one handler serves every row.
+    /// </summary>
+    [Test]
+    [Apartment(ApartmentState.STA)]
+    public void EncodingMenu_ClickingARow_YieldsThatRowsEncoding ()
+    {
+        using var encodingMenu = new ToolStripMenuItem("Encoding");
+        var clicked = new List<Encoding>();
+
+        EncodingMenuBuilder.Fill(encodingMenu, (sender, _) => clicked.Add(EncodingMenuBuilder.EncodingOf(sender as ToolStripItem)));
+
+        foreach (var row in encodingMenu.DropDownItems.Cast<ToolStripItem>().ToList())
+        {
+            row.PerformClick();
+        }
+
+        Assert.That(clicked, Is.EqualTo(EncodingRegistry.OfferedEncodings).AsCollection);
+    }
+}

--- a/src/LogExpert.Tests/Encodings/PersisterXmlEncodingTests.cs
+++ b/src/LogExpert.Tests/Encodings/PersisterXmlEncodingTests.cs
@@ -36,6 +36,7 @@ public class PersisterXmlEncodingTests
     [TestCase("windows-1250", 1250)]
     [TestCase("windows-1252", 1252)]
     [TestCase("utf-8", 65001)]
+    [TestCase("gb2312", 936)]
     public void Load_PersistedEncoding_Resolves (string encodingName, int expectedCodePage)
     {
         WriteLxp($"<encoding name=\"{encodingName}\" />");

--- a/src/LogExpert.Tests/Services/FileOperationServiceTests.cs
+++ b/src/LogExpert.Tests/Services/FileOperationServiceTests.cs
@@ -312,6 +312,7 @@ internal class FileOperationServiceTests : IDisposable
     [Test]
     [TestCase("windows-1250", 1250)]
     [TestCase("windows-1252", 1252)]
+    [TestCase("gb2312", 936)]
     public void AddFileTab_LegacyCodePageDefaultEncoding_ResolvesWithoutOpeningPreferences (string encodingName, int expectedCodePage)
     {
         // Arrange

--- a/src/LogExpert.Tests/Services/MenuToolbarControllerTests.cs
+++ b/src/LogExpert.Tests/Services/MenuToolbarControllerTests.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Windows.Forms;
 
 using LogExpert.Core.EventArguments;
+using LogExpert.Core.Helpers;
 using LogExpert.Dialogs;
 using LogExpert.UI.Controls;
 using LogExpert.UI.Services;
@@ -68,10 +69,10 @@ internal class MenuToolbarControllerTests : IDisposable
 
         _encodingMenu = new ToolStripMenuItem("Encoding") { Name = "encodingToolStripMenuItem" };
         _ = _encodingMenu.DropDownItems.Add(new ToolStripMenuItem("ASCII") { Name = "encodingASCIIToolStripMenuItem" });
-        _ = _encodingMenu.DropDownItems.Add(new ToolStripMenuItem("ANSI") { Name = "encodingANSIToolStripMenuItem" });
         _ = _encodingMenu.DropDownItems.Add(new ToolStripMenuItem("UTF-8") { Name = "encodingUTF8toolStripMenuItem" });
         _ = _encodingMenu.DropDownItems.Add(new ToolStripMenuItem("UTF-16") { Name = "encodingUTF16toolStripMenuItem" });
         _ = _encodingMenu.DropDownItems.Add(new ToolStripMenuItem("ISO-8859-1") { Name = "encodingISO88591toolStripMenuItem" });
+        _ = _encodingMenu.DropDownItems.Add(new ToolStripMenuItem("GB2312") { Name = "encodingGB2312toolStripMenuItem" });
         _ = _viewMenu.DropDownItems.Add(_encodingMenu);
 
         var timeshiftMenu = new ToolStripMenuItem("Timeshift") { Name = "timeshiftToolStripMenuItem" };
@@ -177,6 +178,55 @@ internal class MenuToolbarControllerTests : IDisposable
 
         var utf8Item = FindMenuItem("encodingUTF8toolStripMenuItem");
         Assert.That(utf8Item.Checked, Is.False);
+    }
+
+    /// <summary>
+    /// GB2312 (issue #688) is a row of its own, and picking it must not leave another row checked.
+    /// </summary>
+    [Test]
+    public void UpdateEncodingMenu_Gb2312_ChecksTheGb2312Item ()
+    {
+        _controller.UpdateEncodingMenu(EncodingRegistry.GetEncoding(EncodingRegistry.CODE_PAGE_GB2312));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(FindMenuItem("encodingGB2312toolStripMenuItem").Checked, Is.True);
+            Assert.That(FindMenuItem("encodingUTF8toolStripMenuItem").Checked, Is.False);
+            Assert.That(FindMenuItem("encodingASCIIToolStripMenuItem").Checked, Is.False);
+        });
+    }
+
+    /// <summary>
+    /// A row is identified by its code page, so the two UTF-8 instances the application passes around —
+    /// <see cref="Encoding.UTF8"/> (BOM) and the no-BOM instance the menu applies — are the same row.
+    /// </summary>
+    [Test]
+    public void UpdateEncodingMenu_Utf8WithoutBom_ChecksTheSameRowAsUtf8 ()
+    {
+        _controller.UpdateEncodingMenu(new UTF8Encoding(false));
+
+        Assert.That(FindMenuItem("encodingUTF8toolStripMenuItem").Checked, Is.True);
+    }
+
+    /// <summary>
+    /// <c>Encoding.Default</c> is UTF-8 on .NET — the reason the "ANSI" row was dropped rather than kept
+    /// as a second, indistinguishable UTF-8 row (issue #688). It has to check the UTF-8 row, because that
+    /// is the encoding a file with no preamble and no configured default is actually read with.
+    /// </summary>
+    [Test]
+    public void UpdateEncodingMenu_EncodingDefault_ChecksTheUtf8Row ()
+    {
+        _controller.UpdateEncodingMenu(Encoding.Default);
+
+        Assert.That(FindMenuItem("encodingUTF8toolStripMenuItem").Checked, Is.True);
+    }
+
+    [Test]
+    public void UpdateEncodingMenu_Iso88591_ChecksTheIso88591Item ()
+    {
+        _controller.UpdateEncodingMenu(Encoding.Latin1);
+
+        Assert.That(FindMenuItem("encodingISO88591toolStripMenuItem").Checked, Is.True);
     }
 
     [Test]

--- a/src/LogExpert.Tests/Services/MenuToolbarControllerTests.cs
+++ b/src/LogExpert.Tests/Services/MenuToolbarControllerTests.cs
@@ -67,12 +67,10 @@ internal class MenuToolbarControllerTests : IDisposable
         _ = _viewMenu.DropDownItems.Add(new ToolStripMenuItem("Filter") { Name = "filterToolStripMenuItem" });
         _ = _viewMenu.DropDownItems.Add(new ToolStripMenuItem("Column Finder") { Name = "columnFinderToolStripMenuItem" });
 
+        // Filled by the same builder the Log Tab Window uses, so this fixture cannot describe a menu
+        // the application does not actually build.
         _encodingMenu = new ToolStripMenuItem("Encoding") { Name = "encodingToolStripMenuItem" };
-        _ = _encodingMenu.DropDownItems.Add(new ToolStripMenuItem("ASCII") { Name = "encodingASCIIToolStripMenuItem" });
-        _ = _encodingMenu.DropDownItems.Add(new ToolStripMenuItem("UTF-8") { Name = "encodingUTF8toolStripMenuItem" });
-        _ = _encodingMenu.DropDownItems.Add(new ToolStripMenuItem("UTF-16") { Name = "encodingUTF16toolStripMenuItem" });
-        _ = _encodingMenu.DropDownItems.Add(new ToolStripMenuItem("ISO-8859-1") { Name = "encodingISO88591toolStripMenuItem" });
-        _ = _encodingMenu.DropDownItems.Add(new ToolStripMenuItem("GB2312") { Name = "encodingGB2312toolStripMenuItem" });
+        EncodingMenuBuilder.Fill(_encodingMenu, (_, _) => { });
         _ = _viewMenu.DropDownItems.Add(_encodingMenu);
 
         var timeshiftMenu = new ToolStripMenuItem("Timeshift") { Name = "timeshiftToolStripMenuItem" };
@@ -157,15 +155,25 @@ internal class MenuToolbarControllerTests : IDisposable
         Assert.That(_dragControl.Visible, Is.False);
     }
 
+    /// <summary>
+    /// Exactly one row is checked, and it is the row for the encoding passed in — asserted for every
+    /// offered encoding, so no row can be unreachable.
+    /// </summary>
     [Test]
-    public void UpdateEncodingMenu_Utf8_ChecksCorrectItem ()
+    public void UpdateEncodingMenu_OfferedEncoding_ChecksOnlyThatRow ()
     {
-        _controller.UpdateEncodingMenu(Encoding.UTF8);
+        Assert.Multiple(() =>
+        {
+            foreach (var encoding in EncodingRegistry.OfferedEncodings)
+            {
+                _controller.UpdateEncodingMenu(encoding);
 
-        var utf8Item = FindMenuItem("encodingUTF8toolStripMenuItem");
-        var asciiItem = FindMenuItem("encodingASCIIToolStripMenuItem");
-        Assert.That(utf8Item.Checked, Is.True);
-        Assert.That(asciiItem.Checked, Is.False);
+                Assert.That(
+                    CheckedEncodingRowNames(),
+                    Is.EqualTo(new[] { EncodingMenuBuilder.RowName(encoding) }).AsCollection,
+                    $"'{encoding.HeaderName}' did not check exactly its own row");
+            }
+        });
     }
 
     [Test]
@@ -176,57 +184,50 @@ internal class MenuToolbarControllerTests : IDisposable
         // Then clear
         _controller.UpdateEncodingMenu(null);
 
-        var utf8Item = FindMenuItem("encodingUTF8toolStripMenuItem");
-        Assert.That(utf8Item.Checked, Is.False);
+        Assert.That(CheckedEncodingRowNames(), Is.Empty);
     }
 
     /// <summary>
-    /// GB2312 (issue #688) is a row of its own, and picking it must not leave another row checked.
+    /// A row is identified by its code page, so the UTF-8 instances the application passes around are the
+    /// same row: <see cref="Encoding.UTF8"/> (emits a BOM), a no-BOM instance, and <c>Encoding.Default</c>
+    /// — which is UTF-8 on .NET, and is the reason the "ANSI" row was dropped rather than kept as a
+    /// second, indistinguishable UTF-8 row (issue #688).
     /// </summary>
     [Test]
-    public void UpdateEncodingMenu_Gb2312_ChecksTheGb2312Item ()
+    public void UpdateEncodingMenu_AnyUtf8Instance_ChecksTheUtf8Row ()
     {
-        _controller.UpdateEncodingMenu(EncodingRegistry.GetEncoding(EncodingRegistry.CODE_PAGE_GB2312));
+        var utf8Row = new[] { EncodingMenuBuilder.RowName(Encoding.UTF8) };
 
         Assert.Multiple(() =>
         {
-            Assert.That(FindMenuItem("encodingGB2312toolStripMenuItem").Checked, Is.True);
-            Assert.That(FindMenuItem("encodingUTF8toolStripMenuItem").Checked, Is.False);
-            Assert.That(FindMenuItem("encodingASCIIToolStripMenuItem").Checked, Is.False);
+            foreach (var utf8 in new[] { Encoding.UTF8, new UTF8Encoding(false), Encoding.Default })
+            {
+                _controller.UpdateEncodingMenu(utf8);
+
+                Assert.That(CheckedEncodingRowNames(), Is.EqualTo(utf8Row).AsCollection);
+            }
         });
     }
 
     /// <summary>
-    /// A row is identified by its code page, so the two UTF-8 instances the application passes around —
-    /// <see cref="Encoding.UTF8"/> (BOM) and the no-BOM instance the menu applies — are the same row.
+    /// A file read with an encoding the menu does not offer leaves every row unchecked — checking one
+    /// would claim a row reproduces the file's encoding when clicking it would change it.
     /// </summary>
     [Test]
-    public void UpdateEncodingMenu_Utf8WithoutBom_ChecksTheSameRowAsUtf8 ()
+    public void UpdateEncodingMenu_EncodingThatIsNotOffered_ChecksNothing ()
     {
-        _controller.UpdateEncodingMenu(new UTF8Encoding(false));
+        _controller.UpdateEncodingMenu(Encoding.BigEndianUnicode);
 
-        Assert.That(FindMenuItem("encodingUTF8toolStripMenuItem").Checked, Is.True);
+        Assert.That(CheckedEncodingRowNames(), Is.Empty);
     }
 
-    /// <summary>
-    /// <c>Encoding.Default</c> is UTF-8 on .NET — the reason the "ANSI" row was dropped rather than kept
-    /// as a second, indistinguishable UTF-8 row (issue #688). It has to check the UTF-8 row, because that
-    /// is the encoding a file with no preamble and no configured default is actually read with.
-    /// </summary>
-    [Test]
-    public void UpdateEncodingMenu_EncodingDefault_ChecksTheUtf8Row ()
+    private List<string> CheckedEncodingRowNames ()
     {
-        _controller.UpdateEncodingMenu(Encoding.Default);
-
-        Assert.That(FindMenuItem("encodingUTF8toolStripMenuItem").Checked, Is.True);
-    }
-
-    [Test]
-    public void UpdateEncodingMenu_Iso88591_ChecksTheIso88591Item ()
-    {
-        _controller.UpdateEncodingMenu(Encoding.Latin1);
-
-        Assert.That(FindMenuItem("encodingISO88591toolStripMenuItem").Checked, Is.True);
+        return [.. _encodingMenu.DropDownItems
+            .Cast<ToolStripItem>()
+            .OfType<ToolStripMenuItem>()
+            .Where(row => row.Checked)
+            .Select(row => row.Name)];
     }
 
     [Test]

--- a/src/LogExpert.Tests/StreamReaderTests/LogStreamReaderTest.cs
+++ b/src/LogExpert.Tests/StreamReaderTests/LogStreamReaderTest.cs
@@ -2,6 +2,7 @@ using System.Text;
 
 using LogExpert.Core.Classes.Log.Streamreaders;
 using LogExpert.Core.Entities;
+using LogExpert.Core.Helpers;
 using LogExpert.Core.Interfaces;
 
 using NUnit.Framework;
@@ -292,5 +293,66 @@ public class LogStreamReaderTest
         }
 
         Assert.That(lineCount, Is.EqualTo(expectedLines));
+    }
+
+    /// <summary>
+    /// The legacy reader advances its position per character read, by a per-encoding step
+    /// (<c>GetPosIncPrecomputed</c>). GB2312 (issue #688) is the first offered encoding that is neither
+    /// single-byte nor Unicode — one byte per ASCII character, two per Chinese one — so a step of "1
+    /// byte unless UTF-8 or UTF-16" drifted the position on the first Chinese character and every
+    /// subsequent line started at the wrong offset.
+    /// </summary>
+    [Test]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1303:Do not pass literals as localized parameters", Justification = "Unit Tests")]
+    public void TryReadLine_LegacyReader_Gb2312_TracksTheBytePositionPerLine ()
+    {
+        var gb2312 = EncodingRegistry.GetEncoding(EncodingRegistry.CODE_PAGE_GB2312);
+        string[] lines = ["错误: 连接失败", "INFO 启动完成", "plain ascii", "警告"];
+        var text = string.Join("\n", lines) + "\n";
+
+        using var stream = new MemoryStream(gb2312.GetBytes(text));
+        using var reader = new PositionAwareStreamReaderLegacy(stream, new EncodingOptions { Encoding = gb2312 }, 500);
+
+        var expectedPosition = 0;
+
+        Assert.Multiple(() =>
+        {
+            foreach (var line in lines)
+            {
+                expectedPosition += gb2312.GetByteCount(line + "\n");
+
+                Assert.That(reader.TryReadLine(out var lineMemory), Is.True);
+                Assert.That(lineMemory.Span.ToString(), Is.EqualTo(line));
+                Assert.That(reader.Position, Is.EqualTo(expectedPosition), $"position drifted after '{line}'");
+            }
+        });
+    }
+
+    /// <summary>
+    /// A step of 0 means "measure the character", which is the only correct answer for a variable-width
+    /// encoding. Pinned per offered encoding so a newly offered one cannot silently get a fixed step.
+    /// </summary>
+    [Test]
+    public void GetPosIncPrecomputed_IsAFixedStepOnlyForFixedWidthEncodings ()
+    {
+        Assert.Multiple(() =>
+        {
+            foreach (var encoding in EncodingRegistry.OfferedEncodings)
+            {
+                var step = PositionAwareStreamReaderBase.GetPosIncPrecomputed(encoding);
+
+                if (step != 0)
+                {
+                    Assert.That(
+                        encoding.GetByteCount("a"),
+                        Is.EqualTo(step),
+                        $"'{encoding.HeaderName}' is credited a fixed {step} byte(s) per character");
+                    Assert.That(
+                        encoding.IsSingleByte || encoding is UnicodeEncoding,
+                        Is.True,
+                        $"'{encoding.HeaderName}' is variable-width, so its step has to be measured");
+                }
+            }
+        });
     }
 }

--- a/src/LogExpert.Tests/StreamReaderTests/LogfileReaderEncodingTests.cs
+++ b/src/LogExpert.Tests/StreamReaderTests/LogfileReaderEncodingTests.cs
@@ -100,6 +100,35 @@ public class LogfileReaderEncodingTests
         Assert.That(reader.CurrentEncoding.CodePage, Is.EqualTo(Encoding.Default.CodePage));
     }
 
+    /// <summary>
+    /// GB2312 (issue #688) end to end: the encoding a user picks in Preferences has to survive down to
+    /// the text the grid shows. A file this size stays in one buffer, so the point of the multi-line
+    /// assertion is the byte position the reader keeps between lines — a variable-width encoding is
+    /// where that drifts.
+    /// </summary>
+    [Test]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1303:Do not pass literals as localized parameters", Justification = "Unit Tests")]
+    public void ReadFiles_Gb2312File_DecodesEveryLine ()
+    {
+        var gb2312 = EncodingRegistry.GetEncoding(EncodingRegistry.CODE_PAGE_GB2312);
+        string[] lines = ["错误: 连接失败", "INFO 启动完成", "plain ascii line", "警告"];
+        File.WriteAllText(_tempFile, string.Join("\n", lines) + "\n", gb2312);
+
+        using var reader = CreateReader(new EncodingOptions { DefaultEncoding = gb2312 });
+        reader.ReadFiles();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(reader.CurrentEncoding.CodePage, Is.EqualTo(EncodingRegistry.CODE_PAGE_GB2312));
+            Assert.That(reader.LineCount, Is.EqualTo(lines.Length));
+
+            for (var lineNum = 0; lineNum < lines.Length; lineNum++)
+            {
+                Assert.That(LineText(reader, lineNum), Is.EqualTo(lines[lineNum]));
+            }
+        });
+    }
+
     [Test]
     public void ChangeEncoding_SwitchesTheReportedEncoding ()
     {

--- a/src/LogExpert.Tests/StreamReaderTests/PositionAwareStreamReaderDirectTests.cs
+++ b/src/LogExpert.Tests/StreamReaderTests/PositionAwareStreamReaderDirectTests.cs
@@ -3,6 +3,7 @@ using System.Text;
 
 using LogExpert.Core.Classes.Log.Streamreaders;
 using LogExpert.Core.Entities;
+using LogExpert.Core.Helpers;
 
 using NUnit.Framework;
 
@@ -182,6 +183,21 @@ public class PositionAwareStreamReaderDirectTests
     {
         var text = "Héllo wörld\nCafé résumé\nこんにちは\n";
         ComparePositions(text, Encoding.UTF8);
+    }
+
+    /// <summary>
+    /// GB2312 (issue #688) is the first offered encoding that is neither single-byte nor Unicode: two
+    /// bytes per Chinese character, one per ASCII character, mixed within a line. The direct reader
+    /// advances its byte position by <c>Encoding.GetByteCount</c> over the decoded chars, so a wrong
+    /// assumption there would drift the position from the second line on — and every buffer boundary,
+    /// rollover check and .lxp scroll position is computed from it.
+    /// </summary>
+    [Test]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1303:Do not pass literals as localized parameters", Justification = "Unit Tests")]
+    public void Position_MatchesSystemReader_Gb2312_MixedAsciiAndChinese ()
+    {
+        var text = "2026-07-30 错误: 连接失败\nINFO 启动完成\nplain ascii line\n警告\n";
+        ComparePositions(text, EncodingRegistry.GetEncoding(EncodingRegistry.CODE_PAGE_GB2312));
     }
 
     private static void ComparePositions (string text, Encoding encoding)

--- a/src/LogExpert.UI/Dialogs/LogTabWindow/LogTabWindow.cs
+++ b/src/LogExpert.UI/Dialogs/LogTabWindow/LogTabWindow.cs
@@ -13,7 +13,6 @@ using LogExpert.Core.Config;
 using LogExpert.Core.Entities;
 using LogExpert.Core.Enums;
 using LogExpert.Core.EventArguments;
-using LogExpert.Core.Helpers;
 using LogExpert.Core.Interfaces;
 using LogExpert.Dialogs;
 using LogExpert.UI.Dialogs;
@@ -141,6 +140,10 @@ internal partial class LogTabWindow : Form, ILogTabWindow
             Padding = new Padding(20, 0, 0, 0),
             BackColor = Color.FromKnownColor(KnownColor.Transparent)
         };
+
+        // Built here rather than declared in the designer so the menu and the Preferences combo box
+        // cannot offer different encodings.
+        EncodingMenuBuilder.Fill(encodingToolStripMenuItem, OnEncodingToolStripMenuItemClick);
 
         var index = buttonToolStrip.Items.IndexOfKey("toolStripButtonTail");
 
@@ -446,12 +449,9 @@ internal partial class LogTabWindow : Form, ILogTabWindow
         jumpToPrevToolStripMenuItem.Text = Resources.LogTabWindow_UI_ToolStripMenuItem_jumpToPrevToolStripMenuItem;
         showBookmarkListToolStripMenuItem.Text = Resources.LogTabWindow_UI_ToolStripMenuItem_showBookmarkListToolStripMenuItem;
         columnFinderToolStripMenuItem.Text = Resources.LogTabWindow_UI_ToolStripMenuItem_columnFinderToolStripMenuItem;
+        // The rows below it are labelled with their encoding's header name, not from resources — an
+        // encoding name is the same in every language.
         encodingToolStripMenuItem.Text = Resources.LogTabWindow_UI_ToolStripMenuItem_encodingToolStripMenuItem;
-        encodingASCIIToolStripMenuItem.Text = Resources.LogTabWindow_UI_ToolStripMenuItem_encodingASCIIToolStripMenuItem;
-        encodingISO88591toolStripMenuItem.Text = Resources.LogTabWindow_UI_ToolStripMenuItem_encodingISO88591toolStripMenuItem;
-        encodingUTF8toolStripMenuItem.Text = Resources.LogTabWindow_UI_ToolStripMenuItem_encodingUTF8toolStripMenuItem;
-        encodingUTF16toolStripMenuItem.Text = Resources.LogTabWindow_UI_ToolStripMenuItem_encodingUTF16toolStripMenuItem;
-        encodingGB2312toolStripMenuItem.Text = Resources.LogTabWindow_UI_ToolStripMenuItem_encodingGB2312toolStripMenuItem;
         timeshiftToolStripMenuItem.Text = Resources.LogTabWindow_UI_ToolStripMenuItem_timeshiftToolStripMenuItem;
         timeshiftToolStripTextBox.Text = Resources.LogTabWindow_UI_ToolStripTextBox_timeshiftToolStripTextBox;
         copyMarkedLinesIntoNewTabToolStripMenuItem.Text = Resources.LogTabWindow_UI_ToolStripMenuItem_copyMarkedLinesIntoNewTabToolStripMenuItem;
@@ -2167,34 +2167,19 @@ internal partial class LogTabWindow : Form, ILogTabWindow
         CurrentLogWindow?.JumpPrevBookmark();
     }
 
+    /// <summary>
+    /// One handler for every row of the Encoding menu: the clicked row carries the encoding it stands
+    /// for, so this does not know which encodings are offered.
+    /// </summary>
     [SupportedOSPlatform("windows")]
-    private void OnASCIIToolStripMenuItemClick (object sender, EventArgs e)
+    private void OnEncodingToolStripMenuItemClick (object sender, EventArgs e)
     {
-        CurrentLogWindow?.ChangeEncoding(Encoding.ASCII);
-    }
+        var encoding = EncodingMenuBuilder.EncodingOf(sender as ToolStripItem);
 
-    [SupportedOSPlatform("windows")]
-    private void OnUTF8ToolStripMenuItemClick (object sender, EventArgs e)
-    {
-        CurrentLogWindow?.ChangeEncoding(new UTF8Encoding(false));
-    }
-
-    [SupportedOSPlatform("windows")]
-    private void OnUTF16ToolStripMenuItemClick (object sender, EventArgs e)
-    {
-        CurrentLogWindow?.ChangeEncoding(Encoding.Unicode);
-    }
-
-    [SupportedOSPlatform("windows")]
-    private void OnISO88591ToolStripMenuItemClick (object sender, EventArgs e)
-    {
-        CurrentLogWindow?.ChangeEncoding(Encoding.Latin1);
-    }
-
-    [SupportedOSPlatform("windows")]
-    private void OnGB2312ToolStripMenuItemClick (object sender, EventArgs e)
-    {
-        CurrentLogWindow?.ChangeEncoding(EncodingRegistry.GetEncoding(EncodingRegistry.CODE_PAGE_GB2312));
+        if (encoding != null)
+        {
+            CurrentLogWindow?.ChangeEncoding(encoding);
+        }
     }
 
     [SupportedOSPlatform("windows")]

--- a/src/LogExpert.UI/Dialogs/LogTabWindow/LogTabWindow.cs
+++ b/src/LogExpert.UI/Dialogs/LogTabWindow/LogTabWindow.cs
@@ -13,6 +13,7 @@ using LogExpert.Core.Config;
 using LogExpert.Core.Entities;
 using LogExpert.Core.Enums;
 using LogExpert.Core.EventArguments;
+using LogExpert.Core.Helpers;
 using LogExpert.Core.Interfaces;
 using LogExpert.Dialogs;
 using LogExpert.UI.Dialogs;
@@ -142,12 +143,6 @@ internal partial class LogTabWindow : Form, ILogTabWindow
         };
 
         var index = buttonToolStrip.Items.IndexOfKey("toolStripButtonTail");
-
-        encodingASCIIToolStripMenuItem.Text = Encoding.ASCII.HeaderName;
-        encodingANSIToolStripMenuItem.Text = Encoding.Default.HeaderName;
-        encodingISO88591toolStripMenuItem.Text = Encoding.GetEncoding("iso-8859-1").HeaderName;
-        encodingUTF8toolStripMenuItem.Text = Encoding.UTF8.HeaderName;
-        encodingUTF16toolStripMenuItem.Text = Encoding.Unicode.HeaderName;
 
         if (index != -1)
         {
@@ -453,10 +448,10 @@ internal partial class LogTabWindow : Form, ILogTabWindow
         columnFinderToolStripMenuItem.Text = Resources.LogTabWindow_UI_ToolStripMenuItem_columnFinderToolStripMenuItem;
         encodingToolStripMenuItem.Text = Resources.LogTabWindow_UI_ToolStripMenuItem_encodingToolStripMenuItem;
         encodingASCIIToolStripMenuItem.Text = Resources.LogTabWindow_UI_ToolStripMenuItem_encodingASCIIToolStripMenuItem;
-        encodingANSIToolStripMenuItem.Text = Resources.LogTabWindow_UI_ToolStripMenuItem_encodingANSIToolStripMenuItem;
         encodingISO88591toolStripMenuItem.Text = Resources.LogTabWindow_UI_ToolStripMenuItem_encodingISO88591toolStripMenuItem;
         encodingUTF8toolStripMenuItem.Text = Resources.LogTabWindow_UI_ToolStripMenuItem_encodingUTF8toolStripMenuItem;
         encodingUTF16toolStripMenuItem.Text = Resources.LogTabWindow_UI_ToolStripMenuItem_encodingUTF16toolStripMenuItem;
+        encodingGB2312toolStripMenuItem.Text = Resources.LogTabWindow_UI_ToolStripMenuItem_encodingGB2312toolStripMenuItem;
         timeshiftToolStripMenuItem.Text = Resources.LogTabWindow_UI_ToolStripMenuItem_timeshiftToolStripMenuItem;
         timeshiftToolStripTextBox.Text = Resources.LogTabWindow_UI_ToolStripTextBox_timeshiftToolStripTextBox;
         copyMarkedLinesIntoNewTabToolStripMenuItem.Text = Resources.LogTabWindow_UI_ToolStripMenuItem_copyMarkedLinesIntoNewTabToolStripMenuItem;
@@ -2179,12 +2174,6 @@ internal partial class LogTabWindow : Form, ILogTabWindow
     }
 
     [SupportedOSPlatform("windows")]
-    private void OnANSIToolStripMenuItemClick (object sender, EventArgs e)
-    {
-        CurrentLogWindow?.ChangeEncoding(Encoding.Default);
-    }
-
-    [SupportedOSPlatform("windows")]
     private void OnUTF8ToolStripMenuItemClick (object sender, EventArgs e)
     {
         CurrentLogWindow?.ChangeEncoding(new UTF8Encoding(false));
@@ -2199,7 +2188,13 @@ internal partial class LogTabWindow : Form, ILogTabWindow
     [SupportedOSPlatform("windows")]
     private void OnISO88591ToolStripMenuItemClick (object sender, EventArgs e)
     {
-        CurrentLogWindow?.ChangeEncoding(Encoding.GetEncoding("iso-8859-1"));
+        CurrentLogWindow?.ChangeEncoding(Encoding.Latin1);
+    }
+
+    [SupportedOSPlatform("windows")]
+    private void OnGB2312ToolStripMenuItemClick (object sender, EventArgs e)
+    {
+        CurrentLogWindow?.ChangeEncoding(EncodingRegistry.GetEncoding(EncodingRegistry.CODE_PAGE_GB2312));
     }
 
     [SupportedOSPlatform("windows")]

--- a/src/LogExpert.UI/Dialogs/LogTabWindow/LogTabWindow.designer.cs
+++ b/src/LogExpert.UI/Dialogs/LogTabWindow/LogTabWindow.designer.cs
@@ -1,4 +1,4 @@
-using System.Windows.Forms;
+﻿using System.Windows.Forms;
 using LogExpert.Core.Enums;
 using LogExpert.Dialogs;
 using WeifenLuo.WinFormsUI.Docking;
@@ -59,10 +59,10 @@ namespace LogExpert.UI.Controls.LogTabWindow
             ToolStripSeparator5 = new ToolStripSeparator();
             encodingToolStripMenuItem = new ToolStripMenuItem();
             encodingASCIIToolStripMenuItem = new ToolStripMenuItem();
-            encodingANSIToolStripMenuItem = new ToolStripMenuItem();
             encodingISO88591toolStripMenuItem = new ToolStripMenuItem();
             encodingUTF8toolStripMenuItem = new ToolStripMenuItem();
             encodingUTF16toolStripMenuItem = new ToolStripMenuItem();
+            encodingGB2312toolStripMenuItem = new ToolStripMenuItem();
             ToolStripSeparator6 = new ToolStripSeparator();
             timeshiftToolStripMenuItem = new ToolStripMenuItem();
             timeshiftToolStripTextBox = new ToolStripTextBox();
@@ -438,7 +438,7 @@ namespace LogExpert.UI.Controls.LogTabWindow
             // 
             // encodingToolStripMenuItem
             // 
-            encodingToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] { encodingASCIIToolStripMenuItem, encodingANSIToolStripMenuItem, encodingISO88591toolStripMenuItem, encodingUTF8toolStripMenuItem, encodingUTF16toolStripMenuItem });
+            encodingToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] { encodingASCIIToolStripMenuItem, encodingISO88591toolStripMenuItem, encodingUTF8toolStripMenuItem, encodingUTF16toolStripMenuItem, encodingGB2312toolStripMenuItem });
             encodingToolStripMenuItem.Name = "encodingToolStripMenuItem";
             encodingToolStripMenuItem.Size = new Size(177, 22);
             encodingToolStripMenuItem.Text = "Encoding";
@@ -451,16 +451,6 @@ namespace LogExpert.UI.Controls.LogTabWindow
             encodingASCIIToolStripMenuItem.Size = new Size(132, 22);
             encodingASCIIToolStripMenuItem.Text = "ASCII";
             encodingASCIIToolStripMenuItem.Click += OnASCIIToolStripMenuItemClick;
-            // 
-            // encodingANSIToolStripMenuItem
-            // 
-            encodingANSIToolStripMenuItem.BackColor = SystemColors.Control;
-            encodingANSIToolStripMenuItem.ForeColor = SystemColors.ControlDarkDark;
-            encodingANSIToolStripMenuItem.Name = "encodingANSIToolStripMenuItem";
-            encodingANSIToolStripMenuItem.Size = new Size(132, 22);
-            encodingANSIToolStripMenuItem.Tag = "";
-            encodingANSIToolStripMenuItem.Text = "ANSI";
-            encodingANSIToolStripMenuItem.Click += OnANSIToolStripMenuItemClick;
             // 
             // encodingISO88591toolStripMenuItem
             // 
@@ -488,6 +478,15 @@ namespace LogExpert.UI.Controls.LogTabWindow
             encodingUTF16toolStripMenuItem.Size = new Size(132, 22);
             encodingUTF16toolStripMenuItem.Text = "Unicode";
             encodingUTF16toolStripMenuItem.Click += OnUTF16ToolStripMenuItemClick;
+            // 
+            // encodingGB2312toolStripMenuItem
+            // 
+            encodingGB2312toolStripMenuItem.BackColor = SystemColors.Control;
+            encodingGB2312toolStripMenuItem.ForeColor = SystemColors.ControlDarkDark;
+            encodingGB2312toolStripMenuItem.Name = "encodingGB2312toolStripMenuItem";
+            encodingGB2312toolStripMenuItem.Size = new Size(132, 22);
+            encodingGB2312toolStripMenuItem.Text = "GB2312";
+            encodingGB2312toolStripMenuItem.Click += OnGB2312ToolStripMenuItemClick;
             // 
             // ToolStripSeparator6
             // 
@@ -1143,9 +1142,9 @@ namespace LogExpert.UI.Controls.LogTabWindow
         private System.Windows.Forms.ToolStripMenuItem jumpToPrevToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem encodingToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem encodingASCIIToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem encodingANSIToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem encodingUTF8toolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem encodingUTF16toolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem encodingGB2312toolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem reloadToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem columnizerToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem settingsToolStripMenuItem;

--- a/src/LogExpert.UI/Dialogs/LogTabWindow/LogTabWindow.designer.cs
+++ b/src/LogExpert.UI/Dialogs/LogTabWindow/LogTabWindow.designer.cs
@@ -58,11 +58,6 @@ namespace LogExpert.UI.Controls.LogTabWindow
             columnFinderToolStripMenuItem = new ToolStripMenuItem();
             ToolStripSeparator5 = new ToolStripSeparator();
             encodingToolStripMenuItem = new ToolStripMenuItem();
-            encodingASCIIToolStripMenuItem = new ToolStripMenuItem();
-            encodingISO88591toolStripMenuItem = new ToolStripMenuItem();
-            encodingUTF8toolStripMenuItem = new ToolStripMenuItem();
-            encodingUTF16toolStripMenuItem = new ToolStripMenuItem();
-            encodingGB2312toolStripMenuItem = new ToolStripMenuItem();
             ToolStripSeparator6 = new ToolStripSeparator();
             timeshiftToolStripMenuItem = new ToolStripMenuItem();
             timeshiftToolStripTextBox = new ToolStripTextBox();
@@ -438,55 +433,10 @@ namespace LogExpert.UI.Controls.LogTabWindow
             // 
             // encodingToolStripMenuItem
             // 
-            encodingToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] { encodingASCIIToolStripMenuItem, encodingISO88591toolStripMenuItem, encodingUTF8toolStripMenuItem, encodingUTF16toolStripMenuItem, encodingGB2312toolStripMenuItem });
+            // Rows are added at runtime by EncodingMenuBuilder, from the single offered-encoding list.
             encodingToolStripMenuItem.Name = "encodingToolStripMenuItem";
             encodingToolStripMenuItem.Size = new Size(177, 22);
             encodingToolStripMenuItem.Text = "Encoding";
-            // 
-            // encodingASCIIToolStripMenuItem
-            // 
-            encodingASCIIToolStripMenuItem.BackColor = SystemColors.Control;
-            encodingASCIIToolStripMenuItem.ForeColor = SystemColors.ControlDarkDark;
-            encodingASCIIToolStripMenuItem.Name = "encodingASCIIToolStripMenuItem";
-            encodingASCIIToolStripMenuItem.Size = new Size(132, 22);
-            encodingASCIIToolStripMenuItem.Text = "ASCII";
-            encodingASCIIToolStripMenuItem.Click += OnASCIIToolStripMenuItemClick;
-            // 
-            // encodingISO88591toolStripMenuItem
-            // 
-            encodingISO88591toolStripMenuItem.BackColor = SystemColors.Control;
-            encodingISO88591toolStripMenuItem.ForeColor = SystemColors.ControlDarkDark;
-            encodingISO88591toolStripMenuItem.Name = "encodingISO88591toolStripMenuItem";
-            encodingISO88591toolStripMenuItem.Size = new Size(132, 22);
-            encodingISO88591toolStripMenuItem.Text = "ISO-8859-1";
-            encodingISO88591toolStripMenuItem.Click += OnISO88591ToolStripMenuItemClick;
-            // 
-            // encodingUTF8toolStripMenuItem
-            // 
-            encodingUTF8toolStripMenuItem.BackColor = SystemColors.Control;
-            encodingUTF8toolStripMenuItem.ForeColor = SystemColors.ControlDarkDark;
-            encodingUTF8toolStripMenuItem.Name = "encodingUTF8toolStripMenuItem";
-            encodingUTF8toolStripMenuItem.Size = new Size(132, 22);
-            encodingUTF8toolStripMenuItem.Text = "UTF8";
-            encodingUTF8toolStripMenuItem.Click += OnUTF8ToolStripMenuItemClick;
-            // 
-            // encodingUTF16toolStripMenuItem
-            // 
-            encodingUTF16toolStripMenuItem.BackColor = SystemColors.Control;
-            encodingUTF16toolStripMenuItem.ForeColor = SystemColors.ControlDarkDark;
-            encodingUTF16toolStripMenuItem.Name = "encodingUTF16toolStripMenuItem";
-            encodingUTF16toolStripMenuItem.Size = new Size(132, 22);
-            encodingUTF16toolStripMenuItem.Text = "Unicode";
-            encodingUTF16toolStripMenuItem.Click += OnUTF16ToolStripMenuItemClick;
-            // 
-            // encodingGB2312toolStripMenuItem
-            // 
-            encodingGB2312toolStripMenuItem.BackColor = SystemColors.Control;
-            encodingGB2312toolStripMenuItem.ForeColor = SystemColors.ControlDarkDark;
-            encodingGB2312toolStripMenuItem.Name = "encodingGB2312toolStripMenuItem";
-            encodingGB2312toolStripMenuItem.Size = new Size(132, 22);
-            encodingGB2312toolStripMenuItem.Text = "GB2312";
-            encodingGB2312toolStripMenuItem.Click += OnGB2312ToolStripMenuItemClick;
             // 
             // ToolStripSeparator6
             // 
@@ -1141,10 +1091,6 @@ namespace LogExpert.UI.Controls.LogTabWindow
         private System.Windows.Forms.ToolStripMenuItem jumpToNextToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem jumpToPrevToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem encodingToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem encodingASCIIToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem encodingUTF8toolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem encodingUTF16toolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem encodingGB2312toolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem reloadToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem columnizerToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem settingsToolStripMenuItem;
@@ -1194,7 +1140,6 @@ namespace LogExpert.UI.Controls.LogTabWindow
         private ToolStripMenuItem disableWordHighlightModeToolStripMenuItem;
         private ToolStripMenuItem multifileMaskToolStripMenuItem;
         private ToolStripMenuItem multiFileEnabledStripMenuItem;
-        private ToolStripMenuItem encodingISO88591toolStripMenuItem;
         private ToolStripMenuItem lockInstanceToolStripMenuItem;
         private ToolStripMenuItem newFromClipboardToolStripMenuItem;
         private ToolStripMenuItem openURIToolStripMenuItem;

--- a/src/LogExpert.UI/Dialogs/SettingsDialog.cs
+++ b/src/LogExpert.UI/Dialogs/SettingsDialog.cs
@@ -712,8 +712,8 @@ internal partial class SettingsDialog : Form
     }
 
     /// <summary>
-    /// The encodings offered as the default encoding: ASCII, ISO-8859-1, UTF-8, Unicode, Windows-1250
-    /// and Windows-1252.
+    /// The encodings offered as the default encoding: ASCII, ISO-8859-1, UTF-8, Unicode, Windows-1250,
+    /// Windows-1252 and GB2312.
     /// </summary>
     /// <remarks>
     /// Separate from <see cref="FillEncodingList"/> so the offered set can be asserted without building
@@ -722,6 +722,10 @@ internal partial class SettingsDialog : Form
     /// <see cref="EncodingRegistry"/>) and no two entries may share a code page — <c>Encoding.Default</c>
     /// is deliberately absent because it is code page 65001 just like <see cref="Encoding.UTF8"/>,
     /// differing only in the BOM it emits, which a read-side default encoding never uses.
+    /// <para>
+    /// New entries are appended rather than sorted in, so an existing user's row does not move under
+    /// the cursor on upgrade.
+    /// </para>
     /// </remarks>
     internal static IReadOnlyList<Encoding> GetAvailableEncodings ()
     {
@@ -732,7 +736,8 @@ internal partial class SettingsDialog : Form
             Encoding.UTF8,
             Encoding.Unicode,
             EncodingRegistry.GetEncoding(1250),
-            EncodingRegistry.GetEncoding(1252)
+            EncodingRegistry.GetEncoding(1252),
+            EncodingRegistry.GetEncoding(EncodingRegistry.CODE_PAGE_GB2312)
         ];
     }
 

--- a/src/LogExpert.UI/Dialogs/SettingsDialog.cs
+++ b/src/LogExpert.UI/Dialogs/SettingsDialog.cs
@@ -124,8 +124,8 @@ internal partial class SettingsDialog : Form
     /// <summary>
     /// The encoding the dialog falls back to when the persisted name is unusable — on both the way in
     /// (nothing to select) and the way out (nothing selected). Has to be one of
-    /// <see cref="GetAvailableEncodings"/>, otherwise the combo box shows a blank selection and OK writes
-    /// back a value the list never offered.
+    /// <see cref="EncodingRegistry.OfferedEncodings"/>, otherwise the combo box shows a blank selection
+    /// and OK writes back a value the list never offered.
     /// </summary>
     internal static Encoding FallbackEncoding { get; } = Encoding.UTF8;
 
@@ -696,49 +696,21 @@ internal partial class SettingsDialog : Form
     }
 
     /// <summary>
-    /// Populates the encoding list in the combo box from <see cref="GetAvailableEncodings"/>. The value
-    /// member of the combo box is set to a specific header name defined in the resources.
+    /// Populates the encoding combo box from <see cref="EncodingRegistry.OfferedEncodings"/> — the same
+    /// list the per-file View → Encoding menu is built from. The value member is set to a specific
+    /// header name defined in the resources; WinForms falls back to it for the display text, so each row
+    /// reads as its <see cref="Encoding.HeaderName"/>.
     /// </summary>
     private void FillEncodingList ()
     {
         comboBoxEncoding.Items.Clear();
 
-        foreach (var encoding in GetAvailableEncodings())
+        foreach (var encoding in EncodingRegistry.OfferedEncodings)
         {
             _ = comboBoxEncoding.Items.Add(encoding);
         }
 
         comboBoxEncoding.ValueMember = Resources.SettingsDialog_UI_ComboBox_Encoding_ValueMember_HeaderName;
-    }
-
-    /// <summary>
-    /// The encodings offered as the default encoding: ASCII, ISO-8859-1, UTF-8, Unicode, Windows-1250,
-    /// Windows-1252 and GB2312.
-    /// </summary>
-    /// <remarks>
-    /// Separate from <see cref="FillEncodingList"/> so the offered set can be asserted without building
-    /// the dialog. The selected entry is saved by name and reselected by equality on the next start, so
-    /// every entry has to be resolvable by name (which is why the code pages go through
-    /// <see cref="EncodingRegistry"/>) and no two entries may share a code page — <c>Encoding.Default</c>
-    /// is deliberately absent because it is code page 65001 just like <see cref="Encoding.UTF8"/>,
-    /// differing only in the BOM it emits, which a read-side default encoding never uses.
-    /// <para>
-    /// New entries are appended rather than sorted in, so an existing user's row does not move under
-    /// the cursor on upgrade.
-    /// </para>
-    /// </remarks>
-    internal static IReadOnlyList<Encoding> GetAvailableEncodings ()
-    {
-        return
-        [
-            Encoding.ASCII,
-            Encoding.Latin1,
-            Encoding.UTF8,
-            Encoding.Unicode,
-            EncodingRegistry.GetEncoding(1250),
-            EncodingRegistry.GetEncoding(1252),
-            EncodingRegistry.GetEncoding(EncodingRegistry.CODE_PAGE_GB2312)
-        ];
     }
 
     /// <summary>

--- a/src/LogExpert.UI/Interface/IMenuToolbarController.cs
+++ b/src/LogExpert.UI/Interface/IMenuToolbarController.cs
@@ -34,8 +34,8 @@ internal interface IMenuToolbarController : IDisposable
     void UpdateGuiState (GuiStateEventArgs state, bool timestampControlEnabled);
 
     /// <summary>
-    /// Updates encoding menu to show current encoding.
-    /// Also updates the ANSI menu item header text.
+    /// Checks the encoding menu row the file is currently read with, and unchecks every other row.
+    /// Leaves all rows unchecked when the encoding is null or is one the menu does not offer.
     /// </summary>
     void UpdateEncodingMenu (Encoding currentEncoding);
 

--- a/src/LogExpert.UI/Services/MenuToolbarService/EncodingMenuBuilder.cs
+++ b/src/LogExpert.UI/Services/MenuToolbarService/EncodingMenuBuilder.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Runtime.Versioning;
+using System.Text;
+
+using LogExpert.Core.Helpers;
+
+namespace LogExpert.UI.Services.MenuToolbarService;
+
+/// <summary>
+/// Builds the View → Encoding dropdown from <see cref="EncodingRegistry.OfferedEncodings"/>, and reads
+/// the encoding back off a row.
+/// </summary>
+/// <remarks>
+/// The rows used to be hand-declared in the designer, one per encoding, each with its own click handler
+/// and its own branch in the check-state lookup — so the menu could (and did) drift from the Preferences
+/// list, and adding an encoding meant editing all three places. Here every row carries the
+/// <see cref="Encoding"/> it stands for in its <c>Tag</c>: the handler applies whatever the clicked row
+/// carries and the check-state lookup compares against it, so neither knows the list.
+/// </remarks>
+[SupportedOSPlatform("windows")]
+internal static class EncodingMenuBuilder
+{
+    /// <summary>
+    /// Replaces <paramref name="encodingMenu"/>'s rows with one per offered encoding, labelled with its
+    /// <see cref="Encoding.HeaderName"/> — the same name the Preferences combo box shows.
+    /// </summary>
+    /// <param name="encodingMenu">The Encoding dropdown to fill.</param>
+    /// <param name="onRowClick">Handler for a row click; read the encoding with <see cref="EncodingOf"/>.</param>
+    internal static void Fill (ToolStripMenuItem encodingMenu, EventHandler onRowClick)
+    {
+        ArgumentNullException.ThrowIfNull(encodingMenu);
+
+        encodingMenu.DropDownItems.Clear();
+
+        foreach (var encoding in EncodingRegistry.OfferedEncodings)
+        {
+            var row = new ToolStripMenuItem(encoding.HeaderName)
+            {
+                Name = RowName(encoding),
+                Tag = encoding,
+                // Carried over from the designer-declared rows, which set both on every encoding row.
+                BackColor = SystemColors.Control,
+                ForeColor = SystemColors.ControlDarkDark
+            };
+
+            row.Click += onRowClick;
+
+            _ = encodingMenu.DropDownItems.Add(row);
+        }
+    }
+
+    /// <summary>
+    /// The designer-style name of the row for <paramref name="encoding"/>. Keyed on the code page
+    /// because that is what identifies a row; the header name is display text.
+    /// </summary>
+    internal static string RowName (Encoding encoding)
+    {
+        ArgumentNullException.ThrowIfNull(encoding);
+
+        return $"encoding{encoding.CodePage}ToolStripMenuItem";
+    }
+
+    /// <summary>
+    /// The encoding <paramref name="row"/> stands for, or null when it is not an encoding row.
+    /// </summary>
+    internal static Encoding EncodingOf (ToolStripItem row)
+    {
+        return row?.Tag as Encoding;
+    }
+}

--- a/src/LogExpert.UI/Services/MenuToolbarService/MenuToolbarController.cs
+++ b/src/LogExpert.UI/Services/MenuToolbarService/MenuToolbarController.cs
@@ -4,7 +4,6 @@ using System.Runtime.Versioning;
 using System.Text;
 
 using LogExpert.Core.EventArguments;
-using LogExpert.Core.Helpers;
 using LogExpert.Dialogs;
 using LogExpert.UI.Interface;
 
@@ -37,13 +36,9 @@ internal sealed class MenuToolbarController : IMenuToolbarController
     private ToolStripMenuItem _cellSelectMenuItem;
     private ToolStripMenuItem _columnFinderMenuItem;
 
-    // Encoding menu items
+    // The Encoding dropdown. Its rows are built by EncodingMenuBuilder and carry the encoding they
+    // stand for, so this controller never names an individual encoding.
     private ToolStripMenuItem _encodingMenuItem;
-    private ToolStripMenuItem _encodingAsciiMenuItem;
-    private ToolStripMenuItem _encodingUtf8MenuItem;
-    private ToolStripMenuItem _encodingUtf16MenuItem;
-    private ToolStripMenuItem _encodingIso88591MenuItem;
-    private ToolStripMenuItem _encodingGb2312MenuItem;
 
     // Toolbar items
     private ToolStripButton _bubblesButton;
@@ -97,11 +92,6 @@ internal sealed class MenuToolbarController : IMenuToolbarController
 
         // Encoding menu items
         _encodingMenuItem = FindMenuItem("encodingToolStripMenuItem");
-        _encodingAsciiMenuItem = FindMenuItem("encodingASCIIToolStripMenuItem");
-        _encodingUtf8MenuItem = FindMenuItem("encodingUTF8toolStripMenuItem");
-        _encodingUtf16MenuItem = FindMenuItem("encodingUTF16toolStripMenuItem");
-        _encodingIso88591MenuItem = FindMenuItem("encodingISO88591toolStripMenuItem");
-        _encodingGb2312MenuItem = FindMenuItem("encodingGB2312toolStripMenuItem");
 
         // Toolbar items
         _bubblesButton = FindToolStripItem<ToolStripButton>(_buttonToolbar, "toolStripButtonBubbles");
@@ -201,66 +191,26 @@ internal sealed class MenuToolbarController : IMenuToolbarController
             return;
         }
 
-        // Clear every row through the dropdown rather than row by row, so a row added to the menu
-        // cannot be left checked by a clear list nobody remembered to extend.
-        if (_encodingMenuItem != null)
+        if (_encodingMenuItem == null)
         {
-            foreach (var row in _encodingMenuItem.DropDownItems)
+            return;
+        }
+
+        // Matched by code page, not by instance: several Encoding instances stand for the same row —
+        // the menu applies UTF-8 without a BOM, the Preferences default is Encoding.UTF8 with one, and
+        // Encoding.Default (what a file with neither a preamble nor a configured default is read with)
+        // is a third UTF-8 instance. A file read with an encoding the menu does not offer leaves every
+        // row unchecked, which is honest: no offered row would reproduce it.
+        var currentCodePage = currentEncoding?.CodePage;
+
+        foreach (var row in _encodingMenuItem.DropDownItems)
+        {
+            if (row is ToolStripMenuItem encodingRow)
             {
-                SetCheckedSafe(row as ToolStripMenuItem, false);
+                encodingRow.Checked = currentCodePage != null
+                    && EncodingMenuBuilder.EncodingOf(encodingRow)?.CodePage == currentCodePage;
             }
         }
-
-        SetCheckedSafe(MenuItemFor(currentEncoding), true);
-    }
-
-    /// <summary>
-    /// The encoding menu row representing <paramref name="encoding"/>, or null when the file is read
-    /// with an encoding the menu does not offer (a Preferences default such as windows-1250, say).
-    /// </summary>
-    /// <remarks>
-    /// Matched by code page rather than by runtime type, because several instances stand for the same
-    /// row: the menu applies UTF-8 without a BOM while the Preferences default is
-    /// <see cref="Encoding.UTF8"/> with one, and <c>Encoding.Default</c> — what a file with neither a
-    /// preamble nor a configured default is read with — is a third UTF-8 instance. Type and equality
-    /// checks put those on different rows (or, before the "ANSI" row was dropped, on the row for a
-    /// different encoding entirely).
-    /// </remarks>
-    private ToolStripMenuItem MenuItemFor (Encoding encoding)
-    {
-        if (encoding == null)
-        {
-            return null;
-        }
-
-        var codePage = encoding.CodePage;
-
-        if (codePage == Encoding.ASCII.CodePage)
-        {
-            return _encodingAsciiMenuItem;
-        }
-
-        if (codePage == Encoding.UTF8.CodePage)
-        {
-            return _encodingUtf8MenuItem;
-        }
-
-        if (codePage == Encoding.Unicode.CodePage || codePage == Encoding.BigEndianUnicode.CodePage)
-        {
-            return _encodingUtf16MenuItem;
-        }
-
-        if (codePage == Encoding.Latin1.CodePage)
-        {
-            return _encodingIso88591MenuItem;
-        }
-
-        if (codePage == EncodingRegistry.CODE_PAGE_GB2312)
-        {
-            return _encodingGb2312MenuItem;
-        }
-
-        return null;
     }
 
     public void UpdateHighlightGroups (IEnumerable<string> groups, string selectedGroup)
@@ -437,7 +387,7 @@ internal sealed class MenuToolbarController : IMenuToolbarController
         LogIfNull(_searchMenuItem, "searchToolStripMenuItem");
         LogIfNull(_filterMenuItem, "filterToolStripMenuItem");
         LogIfNull(_timeshiftMenuItem, "timeshiftToolStripMenuItem");
-        LogIfNull(_encodingAsciiMenuItem, "encodingASCIIToolStripMenuItem");
+        LogIfNull(_encodingMenuItem, "encodingToolStripMenuItem");
         LogIfNull(_highlightGroupCombo, "highlightGroupsToolStripComboBox");
         LogIfNull(_lastUsedMenuItem, "lastUsedToolStripMenuItem");
     }

--- a/src/LogExpert.UI/Services/MenuToolbarService/MenuToolbarController.cs
+++ b/src/LogExpert.UI/Services/MenuToolbarService/MenuToolbarController.cs
@@ -4,6 +4,7 @@ using System.Runtime.Versioning;
 using System.Text;
 
 using LogExpert.Core.EventArguments;
+using LogExpert.Core.Helpers;
 using LogExpert.Dialogs;
 using LogExpert.UI.Interface;
 
@@ -37,11 +38,12 @@ internal sealed class MenuToolbarController : IMenuToolbarController
     private ToolStripMenuItem _columnFinderMenuItem;
 
     // Encoding menu items
+    private ToolStripMenuItem _encodingMenuItem;
     private ToolStripMenuItem _encodingAsciiMenuItem;
-    private ToolStripMenuItem _encodingAnsiMenuItem;
     private ToolStripMenuItem _encodingUtf8MenuItem;
     private ToolStripMenuItem _encodingUtf16MenuItem;
     private ToolStripMenuItem _encodingIso88591MenuItem;
+    private ToolStripMenuItem _encodingGb2312MenuItem;
 
     // Toolbar items
     private ToolStripButton _bubblesButton;
@@ -94,11 +96,12 @@ internal sealed class MenuToolbarController : IMenuToolbarController
         _columnFinderMenuItem = FindMenuItem("columnFinderToolStripMenuItem");
 
         // Encoding menu items
+        _encodingMenuItem = FindMenuItem("encodingToolStripMenuItem");
         _encodingAsciiMenuItem = FindMenuItem("encodingASCIIToolStripMenuItem");
-        _encodingAnsiMenuItem = FindMenuItem("encodingANSIToolStripMenuItem");
         _encodingUtf8MenuItem = FindMenuItem("encodingUTF8toolStripMenuItem");
         _encodingUtf16MenuItem = FindMenuItem("encodingUTF16toolStripMenuItem");
         _encodingIso88591MenuItem = FindMenuItem("encodingISO88591toolStripMenuItem");
+        _encodingGb2312MenuItem = FindMenuItem("encodingGB2312toolStripMenuItem");
 
         // Toolbar items
         _bubblesButton = FindToolStripItem<ToolStripButton>(_buttonToolbar, "toolStripButtonBubbles");
@@ -198,41 +201,66 @@ internal sealed class MenuToolbarController : IMenuToolbarController
             return;
         }
 
-        // Clear all checks
-        SetCheckedSafe(_encodingAsciiMenuItem, false);
-        SetCheckedSafe(_encodingAnsiMenuItem, false);
-        SetCheckedSafe(_encodingUtf8MenuItem, false);
-        SetCheckedSafe(_encodingUtf16MenuItem, false);
-        SetCheckedSafe(_encodingIso88591MenuItem, false);
-
-        if (currentEncoding == null)
+        // Clear every row through the dropdown rather than row by row, so a row added to the menu
+        // cannot be left checked by a clear list nobody remembered to extend.
+        if (_encodingMenuItem != null)
         {
-            return;
+            foreach (var row in _encodingMenuItem.DropDownItems)
+            {
+                SetCheckedSafe(row as ToolStripMenuItem, false);
+            }
         }
 
-        if (currentEncoding is ASCIIEncoding)
+        SetCheckedSafe(MenuItemFor(currentEncoding), true);
+    }
+
+    /// <summary>
+    /// The encoding menu row representing <paramref name="encoding"/>, or null when the file is read
+    /// with an encoding the menu does not offer (a Preferences default such as windows-1250, say).
+    /// </summary>
+    /// <remarks>
+    /// Matched by code page rather than by runtime type, because several instances stand for the same
+    /// row: the menu applies UTF-8 without a BOM while the Preferences default is
+    /// <see cref="Encoding.UTF8"/> with one, and <c>Encoding.Default</c> — what a file with neither a
+    /// preamble nor a configured default is read with — is a third UTF-8 instance. Type and equality
+    /// checks put those on different rows (or, before the "ANSI" row was dropped, on the row for a
+    /// different encoding entirely).
+    /// </remarks>
+    private ToolStripMenuItem MenuItemFor (Encoding encoding)
+    {
+        if (encoding == null)
         {
-            SetCheckedSafe(_encodingAsciiMenuItem, true);
-        }
-        else if (currentEncoding.Equals(Encoding.Default))
-        {
-            SetCheckedSafe(_encodingAnsiMenuItem, true);
-        }
-        else if (currentEncoding is UTF8Encoding)
-        {
-            SetCheckedSafe(_encodingUtf8MenuItem, true);
-        }
-        else if (currentEncoding is UnicodeEncoding)
-        {
-            SetCheckedSafe(_encodingUtf16MenuItem, true);
-        }
-        else if (currentEncoding.Equals(Encoding.GetEncoding("iso-8859-1")))
-        {
-            SetCheckedSafe(_encodingIso88591MenuItem, true);
+            return null;
         }
 
-        // Preserve existing behavior: update ANSI display name
-        _ = (_encodingAnsiMenuItem?.Text = Encoding.Default.HeaderName);
+        var codePage = encoding.CodePage;
+
+        if (codePage == Encoding.ASCII.CodePage)
+        {
+            return _encodingAsciiMenuItem;
+        }
+
+        if (codePage == Encoding.UTF8.CodePage)
+        {
+            return _encodingUtf8MenuItem;
+        }
+
+        if (codePage == Encoding.Unicode.CodePage || codePage == Encoding.BigEndianUnicode.CodePage)
+        {
+            return _encodingUtf16MenuItem;
+        }
+
+        if (codePage == Encoding.Latin1.CodePage)
+        {
+            return _encodingIso88591MenuItem;
+        }
+
+        if (codePage == EncodingRegistry.CODE_PAGE_GB2312)
+        {
+            return _encodingGb2312MenuItem;
+        }
+
+        return null;
     }
 
     public void UpdateHighlightGroups (IEnumerable<string> groups, string selectedGroup)


### PR DESCRIPTION
Closes #688.

## What was reported

> from 1.21, it has two utf-8 encoding, but i need gb2312, thanks!

Both halves turned out to be real.

**GB2312 was missing.** It is now offered as the Preferences default encoding and as a row in View → Encoding.

**The "two utf-8 encoding" reproduced.** `LogTabWindow`'s constructor overwrote each encoding row's label with `Encoding.<X>.HeaderName`, *after* the localized resource labels had been applied. `Encoding.Default` is UTF-8 on .NET, so the "ANSI" row rendered as `utf-8` directly above the "UTF8" row, which rendered as `utf-8` too — two rows, same label, same encoding. The ANSI row is dropped (the Preferences combo lost the identical duplicate in #673, for the same reason) and the `HeaderName` overwrite with it.

A third defect fell out while pinning the above: check state was matched by runtime type and equality, testing `Equals(Encoding.Default)` before `is UTF8Encoding`. Clicking "UTF8" applies UTF-8 *without* a BOM, which compares equal to `Encoding.Default` — so the checkmark landed on the ANSI row.

## One offered-encoding list

The Preferences combo and the encoding menu each carried their own list, and they had drifted: the menu lacked windows-1250 and windows-1252, and carried the ANSI row Preferences did not. Adding an encoding meant editing both, plus a third place — the lookup mapping a file's encoding back onto a menu row.

`EncodingRegistry.OfferedEncodings` is now the one list, documenting the invariants both UIs depend on (resolvable by its own header name, no two entries sharing a code page, append rather than sort). Adding an encoding is a one-line change there.

Menu rows are built from it at runtime by `EncodingMenuBuilder` instead of being declared one-by-one in the designer. Each row carries the `Encoding` it stands for in its `Tag`, so the click handler applies whatever the clicked row carries (one handler, was five) and the check-state lookup compares against it (was a cascade naming every encoding, plus a field per row). Rows are labelled with their header name — the same text the combo shows — which retires five resource keys across en/de/zh-CN that were dead anyway, overwritten before anyone saw them.

## A bug GB2312 exposed

`GetPosIncPrecomputed` credited every encoding that is not UTF-8 or UTF-16 with **one byte per character**. That is the step the legacy and XML readers advance their byte position by. GB2312 is the first offered encoding that is neither single-byte nor Unicode (one byte per ASCII character, two per Chinese one), so the position drifted on the first Chinese character and every later line began at the wrong offset — picking GB2312 with `ReaderType.Legacy` would have produced a garbled file. The step is now keyed on `Encoding.IsSingleByte`, with `0` ("measure the character") covering the variable-width case.

## Behaviour changes worth knowing

- The **ANSI row is gone**. Functionally lossless: it applied `Encoding.Default`, which on .NET is UTF-8 without a BOM — byte-identical to what the surviving UTF-8 row applies.
- The menu now **also offers windows-1250, windows-1252 and gb2312**, so a Preferences default of windows-1252 finally shows a checkmark.
- Menu rows are labelled `us-ascii` / `iso-8859-1` / `utf-8` / `utf-16` / `windows-1250` / `windows-1252` / `gb2312` instead of `ASCII` / `ANSI` / `ISO-8859-1` / `UTF8` / `Unicode`, matching the Preferences combo.
- A file read with an encoding the menu does not offer now leaves **every** row unchecked. Previously a UTF-16BE file checked "Unicode", but clicking that row applies UTF-16**LE** — the checkmark was lying.

## Testing

1557 tests pass, build clean with no new warnings. Tests were written red-first at each layer the choice passes through: the offered list, menu check state, the settings JSON and `.lxp` round trips, and the reader stack — where the direct reader's byte positions are asserted against the system reader on mixed ASCII/Chinese lines, and the legacy reader's per-line positions against `GetByteCount`. Both position tests were confirmed to fail without the `GetPosIncPrecomputed` fix.

The list invariants are asserted once against the registry rather than per dialog, and the controller's menu fixture is filled by the real builder, so it cannot describe a menu the application does not build.

Note: code page 936 on Windows is really GBK, a GB2312 superset — it decodes strictly more than requested, so nothing is at risk.