### PR TITLE
fix/SaveLastOpenFilesList()

### DIFF
--- a/src/LogExpert.Tests/LogExpert.Tests.csproj
+++ b/src/LogExpert.Tests/LogExpert.Tests.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-	<!-- Required by TabControllerTests to create themed DockPanel document tabs. -->
+    <!-- Required by TabControllerTests to create themed DockPanel document tabs. -->
     <PackageReference Include="DockPanelSuite.ThemeVS2015" />
   </ItemGroup>
 

--- a/src/LogExpert.Tests/LogExpert.Tests.csproj
+++ b/src/LogExpert.Tests/LogExpert.Tests.csproj
@@ -29,6 +29,8 @@
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+	<!-- Required by TabControllerTests to create themed DockPanel document tabs. -->
+    <PackageReference Include="DockPanelSuite.ThemeVS2015" />
   </ItemGroup>
 
   <ItemGroup Label="Data">

--- a/src/LogExpert.Tests/Services/TabControllerTests.cs
+++ b/src/LogExpert.Tests/Services/TabControllerTests.cs
@@ -40,7 +40,8 @@ internal class TabControllerTests : IDisposable
         {
             Dock = DockStyle.Fill,
             // Match LogExpert's document style; DockingMdi required test form to be an MDI container.
-			// Using DockingWindow both matches production behavior and allows the test to create real tabs without setting up an artificial MDI container.
+            // Use DockingWindow to match production and avoid requiring
+            // an artificial MDI container in this test.
             DocumentStyle = DocumentStyle.DockingWindow,
             Theme = new VS2015LightTheme()
         };
@@ -218,32 +219,7 @@ internal class TabControllerTests : IDisposable
 
     #endregion
 
-    #region Helpers
-
-    private static LogWindow CreateLogWindow (string fileName)
-    {
-        var coordinatorMock = new Mock<ILogWindowCoordinator>();
-        _ = coordinatorMock.Setup(coordinator => coordinator.ResolveHighlightGroup(It.IsAny<string?>(), It.IsAny<string?>())).Returns(new HighlightGroup());
-        _ = coordinatorMock.SetupGet(coordinator => coordinator.SearchParams).Returns(new SearchParams());
-
-        var configManagerMock = new Mock<IConfigManager>();
-        _ = configManagerMock.SetupGet(configManager => configManager.Settings).Returns(new Settings());
-
-        var pluginRegistryMock = new Mock<IPluginRegistry>();
-        _ = pluginRegistryMock.SetupGet(pluginRegistry => pluginRegistry.RegisteredColumnizers).Returns([new DefaultLogfileColumnizer()]);
-
-        return new LogWindow(
-            coordinatorMock.Object,
-            fileName,
-            isTempFile: false,
-            forcePersistenceLoading: false,
-            configManagerMock.Object,
-            pluginRegistryMock.Object);
-    }
-
-    #endregion
-    
-	#region GetAllWindows Tests
+    #region GetAllWindows Tests
 
     [Test]
     public void GetAllWindows_WhenEmpty_ReturnsEmptyList ()
@@ -365,8 +341,7 @@ internal class TabControllerTests : IDisposable
         // Arrange
         using var controller = new TabController();
 
-       // CreateLogWindow can now provide a non-null LogWindow when needed.
-       // This test verifies that null argument validation happens before the initialization check.
+        // Validate the argument before checking whether the controller is initialized.
         var ex = Assert.Throws<ArgumentNullException>(() => controller.AddWindow(null, "Test"));
         Assert.That(ex.ParamName, Is.EqualTo("window"));
     }
@@ -460,6 +435,31 @@ internal class TabControllerTests : IDisposable
 
         // Act & Assert - should not throw
         Assert.DoesNotThrow(_tabController.SwitchToPreviousWindow);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static LogWindow CreateLogWindow (string fileName)
+    {
+        var coordinatorMock = new Mock<ILogWindowCoordinator>();
+        _ = coordinatorMock.Setup(coordinator => coordinator.ResolveHighlightGroup(It.IsAny<string?>(), It.IsAny<string?>())).Returns(new HighlightGroup());
+        _ = coordinatorMock.SetupGet(coordinator => coordinator.SearchParams).Returns(new SearchParams());
+
+        var configManagerMock = new Mock<IConfigManager>();
+        _ = configManagerMock.SetupGet(configManager => configManager.Settings).Returns(new Settings());
+
+        var pluginRegistryMock = new Mock<IPluginRegistry>();
+        _ = pluginRegistryMock.SetupGet(pluginRegistry => pluginRegistry.RegisteredColumnizers).Returns([new DefaultLogfileColumnizer()]);
+
+        return new LogWindow(
+            coordinatorMock.Object,
+            fileName,
+            isTempFile: false,
+            forcePersistenceLoading: false,
+            configManagerMock.Object,
+            pluginRegistryMock.Object);
     }
 
     #endregion

--- a/src/LogExpert.Tests/Services/TabControllerTests.cs
+++ b/src/LogExpert.Tests/Services/TabControllerTests.cs
@@ -1,7 +1,13 @@
 using System.Runtime.Versioning;
 
+using LogExpert.Core.Config;
+using LogExpert.Core.Entities;
+using LogExpert.Core.Interfaces;
 using LogExpert.UI.Controls.LogWindow;
+using LogExpert.UI.Interface;
 using LogExpert.UI.Services.TabControllerService;
+
+using Moq;
 
 using NUnit.Framework;
 
@@ -11,11 +17,8 @@ namespace LogExpert.Tests.Services;
 
 /// <summary>
 /// Unit tests for TabController.
-/// Note: Many tests are limited because LogWindow is a complex WinForms control that cannot be easily mocked or
-/// subclassed. Tests that require actual LogWindow instances would need to be run as integration tests with full UI
-/// infrastructure.
-/// These tests focus on the core TabController functionality that can be tested without instantiating LogWindow
-/// objects.
+/// Most tests focus on behavior that does not require LogWindow instances.
+/// Tests that verify DockPanel tab order create real LogWindow instances through CreateLogWindow.
 /// </summary>
 [TestFixture]
 [SupportedOSPlatform("windows")]
@@ -36,7 +39,10 @@ internal class TabControllerTests : IDisposable
         _dockPanel = new DockPanel
         {
             Dock = DockStyle.Fill,
-            DocumentStyle = DocumentStyle.DockingMdi
+            // Match LogExpert's document style; DockingMdi required test form to be an MDI container.
+			// Using DockingWindow both matches production behavior and allows the test to create real tabs without setting up an artificial MDI container.
+            DocumentStyle = DocumentStyle.DockingWindow,
+            Theme = new VS2015LightTheme()
         };
         _testForm.Controls.Add(_dockPanel);
         _testForm.Show(); // Must show form for DockPanel to work
@@ -191,9 +197,53 @@ internal class TabControllerTests : IDisposable
         Assert.That(result, Is.InstanceOf<IReadOnlyList<LogWindow>>());
     }
 
+    [Test]
+    public void GetAllWindowsFromDockPanel_ReturnsDisplayedWindowsInTabOrder ()
+    {
+        // Arrange
+        using var firstWindow = CreateLogWindow("first.log");
+        using var secondWindow = CreateLogWindow("second.log");
+        using var thirdWindow = CreateLogWindow("third.log");
+
+        _tabController.AddWindow(firstWindow, "first.log");
+        _tabController.AddWindow(secondWindow, "second.log");
+        _tabController.AddWindow(thirdWindow, "third.log");
+
+        // Act
+        var result = _tabController.GetAllWindowsFromDockPanel();
+
+        // Assert
+        Assert.That(result, Is.EqualTo(new[] { firstWindow, secondWindow, thirdWindow }));
+    }
+
     #endregion
 
-    #region GetAllWindows Tests
+    #region Helpers
+
+    private static LogWindow CreateLogWindow (string fileName)
+    {
+        var coordinatorMock = new Mock<ILogWindowCoordinator>();
+        _ = coordinatorMock.Setup(coordinator => coordinator.ResolveHighlightGroup(It.IsAny<string?>(), It.IsAny<string?>())).Returns(new HighlightGroup());
+        _ = coordinatorMock.SetupGet(coordinator => coordinator.SearchParams).Returns(new SearchParams());
+
+        var configManagerMock = new Mock<IConfigManager>();
+        _ = configManagerMock.SetupGet(configManager => configManager.Settings).Returns(new Settings());
+
+        var pluginRegistryMock = new Mock<IPluginRegistry>();
+        _ = pluginRegistryMock.SetupGet(pluginRegistry => pluginRegistry.RegisteredColumnizers).Returns([new DefaultLogfileColumnizer()]);
+
+        return new LogWindow(
+            coordinatorMock.Object,
+            fileName,
+            isTempFile: false,
+            forcePersistenceLoading: false,
+            configManagerMock.Object,
+            pluginRegistryMock.Object);
+    }
+
+    #endregion
+    
+	#region GetAllWindows Tests
 
     [Test]
     public void GetAllWindows_WhenEmpty_ReturnsEmptyList ()
@@ -315,10 +365,8 @@ internal class TabControllerTests : IDisposable
         // Arrange
         using var controller = new TabController();
 
-        // Create a mock-like object that's not null to avoid ArgumentNullException
-        // We need to test that the "not initialized" check happens
-        // Unfortunately, LogWindow cannot be instantiated without its dependencies
-        // So we can only verify the ArgumentNullException is thrown first for null
+       // CreateLogWindow can now provide a non-null LogWindow when needed.
+       // This test verifies that null argument validation happens before the initialization check.
         var ex = Assert.Throws<ArgumentNullException>(() => controller.AddWindow(null, "Test"));
         Assert.That(ex.ParamName, Is.EqualTo("window"));
     }

--- a/src/LogExpert.UI/Services/TabControllerService/TabController.cs
+++ b/src/LogExpert.UI/Services/TabControllerService/TabController.cs
@@ -461,12 +461,29 @@ internal class TabController : ITabController
     /// <returns>Read-only list of all LogWindows in the DockPanel</returns>
     public IReadOnlyList<LogWindow> GetAllWindowsFromDockPanel ()
     {
-        return !_initialized || _dockPanel == null
-            ? []
-            : _dockPanel.Panes
-                .SelectMany(pane => pane.DisplayingContents.OfType<LogWindow>())
-                .ToList()
-                .AsReadOnly();
+        if (!_initialized || _dockPanel == null)
+        {
+            return [];
+        }
+
+        var windows = new List<LogWindow>();
+
+        foreach (DockPane pane in _dockPanel.Panes)
+        {
+            var displayingContents = pane.DisplayingContents;
+
+        // Use 'for' instead of 'foreach': DisplayingContents exposes displayed tabs through Count and its indexer.
+        // 'foreach' uses the inherited ReadOnlyCollection enumerator and does not return displayed tabs.
+            for (int index = 0; index < displayingContents.Count; index++)
+            {
+                if (displayingContents[index] is LogWindow logWindow)
+                {
+                    windows.Add(logWindow);
+                }
+            }
+        }
+
+        return windows.AsReadOnly();
     }
 
     #endregion

--- a/src/LogExpert.UI/Services/TabControllerService/TabController.cs
+++ b/src/LogExpert.UI/Services/TabControllerService/TabController.cs
@@ -472,8 +472,8 @@ internal class TabController : ITabController
         {
             var displayingContents = pane.DisplayingContents;
 
-        // Use 'for' instead of 'foreach': DisplayingContents exposes displayed tabs through Count and its indexer.
-        // 'foreach' uses the inherited ReadOnlyCollection enumerator and does not return displayed tabs.
+            // Use 'for' instead of 'foreach': DisplayingContents exposes displayed tabs through Count and its indexer.
+            // 'foreach' uses the inherited ReadOnlyCollection enumerator and does not return displayed tabs.
             for (int index = 0; index < displayingContents.Count; index++)
             {
                 if (displayingContents[index] is LogWindow logWindow)


### PR DESCRIPTION
Fix for clearing "LastOpenFilesList" on app exit. 
When app closes, it looks like it wipes the set of files to restore.

Before exit:
<img width="537" height="68" alt="image" src="https://github.com/user-attachments/assets/2b421ced-54ad-4bf3-b387-4943d9530a44" />

After exit:
<img width="321" height="53" alt="image" src="https://github.com/user-attachments/assets/d1e44df9-e1f9-4bda-b666-1fcf3daecf91" />


Also fixes two other places (both places are affected by this fix and should now work correctly):
  - **Close other tabs** (`LogTabWindow.cs:2326`)
  - **Session-save file list** (`LogTabWindow.cs:2410`)