### PR TITLE
feat: three-way color mode (Light/Dark/System) replacing the DarkMode bool

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -265,7 +265,7 @@ LogExpert/
 
 - UI components in `LogExpert.UI` project
 - Follow existing High DPI patterns (no AutoScale on controls)
-- Test with both light and dark mode (see `SetDarkMode()` in Program.cs)
+- Test with both light and dark mode (see `SetColorMode()` in Program.cs; the `ColorMode` preference is Light/Dark/System)
 - Use localization resources from `LogExpert.Resources` project
 - Windows Forms designer files: `*.designer.cs`
 

--- a/src/LogExpert.Core/Config/ColorMode.cs
+++ b/src/LogExpert.Core/Config/ColorMode.cs
@@ -1,0 +1,27 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace LogExpert.Core.Config;
+
+/// <summary>
+/// Color scheme the application applies at startup (issue #698).
+/// </summary>
+[Serializable]
+[JsonConverter(typeof(StringEnumConverter))]
+public enum ColorMode
+{
+    /// <summary>
+    /// Forced light mode, ignoring the Windows theme (maps to SystemColorMode.Classic).
+    /// </summary>
+    Light = 0,
+
+    /// <summary>
+    /// Forced dark mode, ignoring the Windows theme.
+    /// </summary>
+    Dark = 1,
+
+    /// <summary>
+    /// Follow the Windows theme.
+    /// </summary>
+    System = 2,
+}

--- a/src/LogExpert.Core/Config/Preferences.cs
+++ b/src/LogExpert.Core/Config/Preferences.cs
@@ -79,7 +79,44 @@ public class Preferences
 
     public bool AskForClose { get; set; }
 
-    public bool DarkMode { get; set; }
+    /// <summary>
+    /// Color scheme applied at startup: forced light, forced dark, or follow the Windows theme.
+    /// Takes effect after a restart. Replaces the old bool <c>DarkMode</c> setting (issue #698).
+    /// </summary>
+    public ColorMode ColorMode
+    {
+        get => _colorMode;
+        set
+        {
+            _colorMode = value;
+            _colorModeAssigned = true;
+        }
+    }
+
+    private ColorMode _colorMode = ColorMode.Light;
+
+    private bool _colorModeAssigned;
+
+    /// <summary>
+    /// Legacy property for backward compatibility with old settings files that stored the color scheme as the bool
+    /// "DarkMode". true maps to <see cref="ColorMode.Dark"/>, false to <see cref="ColorMode.Light"/> — an unchecked
+    /// box meant forced light, not follow-OS (issue #698). An explicit <see cref="ColorMode"/> value always wins.
+    /// This setter redirects data on load; the property is never written back.
+    /// </summary>
+    [Obsolete("This property exists only for backward compatibility with old settings files. Use ColorMode instead. This will be removed with version 1.50")]
+    [Newtonsoft.Json.JsonProperty("DarkMode", DefaultValueHandling = Newtonsoft.Json.DefaultValueHandling.Ignore, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+    [System.Text.Json.Serialization.JsonIgnore]
+    public bool? DarkMode
+    {
+        get => null; // Always return null so Newtonsoft.Json won't serialize this property
+        set
+        {
+            if (!_colorModeAssigned && value.HasValue)
+            {
+                _colorMode = value.Value ? ColorMode.Dark : ColorMode.Light;
+            }
+        }
+    }
 
     [Obsolete("This setting is no longer used and will be removed in version 1.50. The 'UseLegacyReader' now works with ReaderType.Legacy")]
     [System.Text.Json.Serialization.JsonIgnore]

--- a/src/LogExpert.Resources/Resources.Designer.cs
+++ b/src/LogExpert.Resources/Resources.Designer.cs
@@ -5194,11 +5194,11 @@ namespace LogExpert {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Dark Mode (restart required).
+        ///   Looks up a localized string similar to Color mode (restart required).
         /// </summary>
-        public static string SettingsDialog_UI_CheckBox_checkBoxDarkMode {
+        public static string SettingsDialog_UI_Label_labelColorMode {
             get {
-                return ResourceManager.GetString("SettingsDialog_UI_CheckBox_checkBoxDarkMode", resourceCulture);
+                return ResourceManager.GetString("SettingsDialog_UI_Label_labelColorMode", resourceCulture);
             }
         }
         

--- a/src/LogExpert.Resources/Resources.de.resx
+++ b/src/LogExpert.Resources/Resources.de.resx
@@ -976,8 +976,8 @@ Damit die anderen Fenster beim Auswählen einer Zeile (Mausklick oder Pfeiltaste
   <data name="SettingsDialog_UI_CheckBox_checkBoxFollowTail" xml:space="preserve">
 		<value>Dem Ende folgen aktivieren</value>
 	</data>
-  <data name="SettingsDialog_UI_CheckBox_checkBoxDarkMode" xml:space="preserve">
-		<value>Dark Mode (neustart benötigt)</value>
+  <data name="SettingsDialog_UI_Label_labelColorMode" xml:space="preserve">
+		<value>Farbmodus (Neustart benötigt)</value>
 	</data>
   <data name="SettingsDialog_UI_CheckBox_checkBoxAskCloseTabs" xml:space="preserve">
 		<value>Fragen vor dem schließen des Tabs</value>

--- a/src/LogExpert.Resources/Resources.resx
+++ b/src/LogExpert.Resources/Resources.resx
@@ -863,8 +863,8 @@ Checked tools will appear in the icon bar. All other tools are available in the 
   <data name="SettingsDialog_UI_CheckBox_checkBoxAskCloseTabs" xml:space="preserve">
         <value>Ask before closing tabs</value>
     </data>
-  <data name="SettingsDialog_UI_CheckBox_checkBoxDarkMode" xml:space="preserve">
-        <value>Dark Mode (restart required)</value>
+  <data name="SettingsDialog_UI_Label_labelColorMode" xml:space="preserve">
+        <value>Color mode (restart required)</value>
     </data>
   <data name="SettingsDialog_UI_CheckBox_checkBoxFollowTail" xml:space="preserve">
         <value>Follow tail enabled</value>

--- a/src/LogExpert.Resources/Resources.zh-CN.resx
+++ b/src/LogExpert.Resources/Resources.zh-CN.resx
@@ -760,8 +760,8 @@
   <data name="SettingsDialog_UI_CheckBox_checkBoxAskCloseTabs" xml:space="preserve">
     <value>关闭标签页前询问</value>
   </data>
-  <data name="SettingsDialog_UI_CheckBox_checkBoxDarkMode" xml:space="preserve">
-    <value>深色模式（需重启生效）</value>
+  <data name="SettingsDialog_UI_Label_labelColorMode" xml:space="preserve">
+    <value>颜色模式（需重启生效）</value>
   </data>
   <data name="SettingsDialog_UI_CheckBox_checkBoxFollowTail" xml:space="preserve">
     <value>启用跟随尾部</value>

--- a/src/LogExpert.Tests/ConfigManagerTests/PreferencesColorModeTests.cs
+++ b/src/LogExpert.Tests/ConfigManagerTests/PreferencesColorModeTests.cs
@@ -1,0 +1,79 @@
+using LogExpert.Core.Config;
+
+using Newtonsoft.Json;
+
+using NUnit.Framework;
+
+namespace LogExpert.Tests.ConfigManagerTests;
+
+[TestFixture]
+public class PreferencesColorModeTests
+{
+    [Test]
+    public void Deserialize_LegacyDarkModeTrue_MapsToDark ()
+    {
+        const string legacyJson = "{\"DarkMode\": true}";
+
+        var prefs = JsonConvert.DeserializeObject<Preferences>(legacyJson);
+
+        Assert.That(prefs, Is.Not.Null);
+        Assert.That(prefs!.ColorMode, Is.EqualTo(ColorMode.Dark));
+    }
+
+    [Test]
+    public void Deserialize_LegacyDarkModeFalse_MapsToLight ()
+    {
+        // Unchecked "Dark Mode" meant forced light, not follow-OS (issue #698).
+        const string legacyJson = "{\"DarkMode\": false}";
+
+        var prefs = JsonConvert.DeserializeObject<Preferences>(legacyJson);
+
+        Assert.That(prefs, Is.Not.Null);
+        Assert.That(prefs!.ColorMode, Is.EqualTo(ColorMode.Light));
+    }
+
+    [Test]
+    public void Deserialize_NoColorSetting_DefaultsToLight ()
+    {
+        const string legacyJson = "{}";
+
+        var prefs = JsonConvert.DeserializeObject<Preferences>(legacyJson);
+
+        Assert.That(prefs, Is.Not.Null);
+        Assert.That(prefs!.ColorMode, Is.EqualTo(ColorMode.Light));
+    }
+
+    [Test]
+    public void Deserialize_ColorModeString_ReadsEnum ()
+    {
+        const string json = "{\"ColorMode\": \"System\"}";
+
+        var prefs = JsonConvert.DeserializeObject<Preferences>(json);
+
+        Assert.That(prefs, Is.Not.Null);
+        Assert.That(prefs!.ColorMode, Is.EqualTo(ColorMode.System));
+    }
+
+    [Test]
+    public void Deserialize_ColorModeWinsOverLegacyDarkMode ()
+    {
+        // A file that carries both keys must obey the new one, regardless of key order.
+        const string json = "{\"ColorMode\": \"Light\", \"DarkMode\": true}";
+
+        var prefs = JsonConvert.DeserializeObject<Preferences>(json);
+
+        Assert.That(prefs, Is.Not.Null);
+        Assert.That(prefs!.ColorMode, Is.EqualTo(ColorMode.Light));
+    }
+
+    [Test]
+    public void Serialize_WritesColorModeAsString_AndNoLegacyDarkMode ()
+    {
+        var prefs = new Preferences { ColorMode = ColorMode.System };
+
+        var json = JsonConvert.SerializeObject(prefs);
+
+        Assert.That(json, Does.Contain("\"ColorMode\":\"System\""));
+        Assert.That(json, Does.Not.Contain("\"DarkMode\""));
+    }
+}

--- a/src/LogExpert.UI/Dialogs/SettingsDialog.Designer.cs
+++ b/src/LogExpert.UI/Dialogs/SettingsDialog.Designer.cs
@@ -41,7 +41,8 @@ partial class SettingsDialog
         groupBoxDefaults = new GroupBox();
         labelLanguage = new Label();
         comboBoxLanguage = new ComboBox();
-        checkBoxDarkMode = new CheckBox();
+        labelColorMode = new Label();
+        comboBoxColorMode = new ComboBox();
         checkBoxFollowTail = new CheckBox();
         checkBoxColumnFinder = new CheckBox();
         checkBoxSyncFilter = new CheckBox();
@@ -495,7 +496,8 @@ partial class SettingsDialog
         // 
         groupBoxDefaults.Controls.Add(labelLanguage);
         groupBoxDefaults.Controls.Add(comboBoxLanguage);
-        groupBoxDefaults.Controls.Add(checkBoxDarkMode);
+        groupBoxDefaults.Controls.Add(labelColorMode);
+        groupBoxDefaults.Controls.Add(comboBoxColorMode);
         groupBoxDefaults.Controls.Add(checkBoxFollowTail);
         groupBoxDefaults.Controls.Add(checkBoxColumnFinder);
         groupBoxDefaults.Controls.Add(checkBoxSyncFilter);
@@ -529,17 +531,26 @@ partial class SettingsDialog
         comboBoxLanguage.Size = new Size(177, 23);
         comboBoxLanguage.TabIndex = 9;
         toolTip.SetToolTip(comboBoxLanguage, "Userinterface language");
-        // 
-        // checkBoxDarkMode
-        // 
-        checkBoxDarkMode.AutoSize = true;
-        checkBoxDarkMode.Location = new Point(9, 144);
-        checkBoxDarkMode.Margin = new Padding(4);
-        checkBoxDarkMode.Name = "checkBoxDarkMode";
-        checkBoxDarkMode.Size = new Size(175, 19);
-        checkBoxDarkMode.TabIndex = 6;
-        checkBoxDarkMode.Text = "Dark Mode (restart required)";
-        checkBoxDarkMode.UseVisualStyleBackColor = true;
+        //
+        // labelColorMode
+        //
+        labelColorMode.AutoSize = true;
+        labelColorMode.Location = new Point(9, 147);
+        labelColorMode.Margin = new Padding(4, 0, 4, 0);
+        labelColorMode.Name = "labelColorMode";
+        labelColorMode.Size = new Size(160, 15);
+        labelColorMode.TabIndex = 18;
+        labelColorMode.Text = "Color mode (restart required)";
+        //
+        // comboBoxColorMode
+        //
+        comboBoxColorMode.DropDownStyle = ComboBoxStyle.DropDownList;
+        comboBoxColorMode.FormattingEnabled = true;
+        comboBoxColorMode.Location = new Point(204, 144);
+        comboBoxColorMode.Margin = new Padding(4, 5, 4, 5);
+        comboBoxColorMode.Name = "comboBoxColorMode";
+        comboBoxColorMode.Size = new Size(177, 23);
+        comboBoxColorMode.TabIndex = 6;
         // 
         // checkBoxFollowTail
         // 
@@ -2280,7 +2291,8 @@ partial class SettingsDialog
     private System.Windows.Forms.CheckBox checkBoxPortableMode;
     private System.Windows.Forms.RadioButton radioButtonSessionApplicationStartupDir;
     private System.Windows.Forms.CheckBox checkBoxShowErrorMessageOnlyOneInstance;
-    private System.Windows.Forms.CheckBox checkBoxDarkMode;
+    private System.Windows.Forms.Label labelColorMode;
+    private System.Windows.Forms.ComboBox comboBoxColorMode;
     private System.Windows.Forms.NumericUpDown upDownMaximumLineLength;
     private System.Windows.Forms.Label labelMaximumLineLength;
     private System.Windows.Forms.Label labelWarningMaximumLineLength;

--- a/src/LogExpert.UI/Dialogs/SettingsDialog.cs
+++ b/src/LogExpert.UI/Dialogs/SettingsDialog.cs
@@ -185,7 +185,7 @@ internal partial class SettingsDialog : Form
 
         FillPortableMode();
 
-        checkBoxDarkMode.Checked = Preferences.DarkMode;
+        FillColorModeList();
         checkBoxTimestamp.Checked = Preferences.TimestampControl;
         checkBoxSyncFilter.Checked = Preferences.FilterSync;
         checkBoxFilterTail.Checked = Preferences.FilterTail;
@@ -323,6 +323,19 @@ internal partial class SettingsDialog : Form
         }
 
         comboBoxReaderType.SelectedItem = Preferences.ReaderType;
+    }
+
+    private void FillColorModeList ()
+    {
+        foreach (var colorMode in Enum.GetValues<ColorMode>())
+        {
+            if (!comboBoxColorMode.Items.Contains(colorMode))
+            {
+                _ = comboBoxColorMode.Items.Add(colorMode);
+            }
+        }
+
+        comboBoxColorMode.SelectedItem = Preferences.ColorMode;
     }
 
     internal void FillPortableMode ()
@@ -818,7 +831,7 @@ internal partial class SettingsDialog : Form
         Preferences.MaximumFilterEntries = (int)upDownMaximumFilterEntries.Value;
         Preferences.MaximumFilterEntriesDisplayed = (int)upDownMaximumFilterEntriesDisplayed.Value;
         Preferences.ShowErrorMessageAllowOnlyOneInstances = checkBoxShowErrorMessageOnlyOneInstance.Checked;
-        Preferences.DarkMode = checkBoxDarkMode.Checked;
+        Preferences.ColorMode = comboBoxColorMode.SelectedItem is ColorMode colorMode ? colorMode : ColorMode.Light;
         Preferences.MaxLineLength = (int)upDownMaximumLineLength.Value;
         Preferences.MaxDisplayLength = Math.Min((int)upDownMaxDisplayLength.Value, (int)upDownMaximumLineLength.Value);
 

--- a/src/LogExpert.UI/Dialogs/SettingsDialog.cs
+++ b/src/LogExpert.UI/Dialogs/SettingsDialog.cs
@@ -327,12 +327,9 @@ internal partial class SettingsDialog : Form
 
     private void FillColorModeList ()
     {
-        foreach (var colorMode in Enum.GetValues<ColorMode>())
+        foreach (var colorMode in Enum.GetValues<ColorMode>().Where(cm => !comboBoxColorMode.Items.Contains(cm)))
         {
-            if (!comboBoxColorMode.Items.Contains(colorMode))
-            {
-                _ = comboBoxColorMode.Items.Add(colorMode);
-            }
+            _ = comboBoxColorMode.Items.Add(colorMode);
         }
 
         comboBoxColorMode.SelectedItem = Preferences.ColorMode;

--- a/src/LogExpert/Program.cs
+++ b/src/LogExpert/Program.cs
@@ -257,7 +257,7 @@ internal static class Program
         }
         else
         {
-            Application.SetColorMode(SystemColorMode.System);
+            Application.SetColorMode(SystemColorMode.Classic);
         }
     }
 

--- a/src/LogExpert/Program.cs
+++ b/src/LogExpert/Program.cs
@@ -130,7 +130,7 @@ internal static class Program
             _ = PluginRegistry.PluginRegistry.Create(ConfigManager.Instance.ActiveConfigDir, ConfigManager.Instance.Settings.Preferences.PollingInterval);
 
             SetCulture();
-            SetDarkMode();
+            SetColorMode();
 
             ColumnizerLib.Column.SetMaxDisplayLength(ConfigManager.Instance.Settings.Preferences.MaxDisplayLength);
 
@@ -248,17 +248,14 @@ internal static class Program
     }
 
     [SupportedOSPlatform("windows")]
-    private static void SetDarkMode ()
+    private static void SetColorMode ()
     {
-        var darkModeEnabled = ConfigManager.Instance.Settings.Preferences.DarkMode;
-        if (darkModeEnabled)
+        Application.SetColorMode(ConfigManager.Instance.Settings.Preferences.ColorMode switch
         {
-            Application.SetColorMode(SystemColorMode.Dark);
-        }
-        else
-        {
-            Application.SetColorMode(SystemColorMode.Classic);
-        }
+            ColorMode.Dark => SystemColorMode.Dark,
+            ColorMode.System => SystemColorMode.System,
+            _ => SystemColorMode.Classic,
+        });
     }
 
     [SupportedOSPlatform("windows")]


### PR DESCRIPTION
Closes #698

## What

Replaces the boolean **Dark Mode** preference with a three-way **Color mode** setting:

- **Light** – forced light mode (`SystemColorMode.Classic`), ignores the Windows theme
- **Dark** – forced dark mode (`SystemColorMode.Dark`)
- **System** – follows the Windows theme (`SystemColorMode.System`)

The Settings dialog now shows a "Color mode (restart required)" dropdown in the Defaults group instead of the old checkbox (labels localized in en/de/zh-CN).

## Why

#698: with the old bool, unchecked used to mean "follow the OS", so users on a dark Windows theme could never force light mode. The interim fix mapped unchecked to forced light — which in turn made "follow the OS" unreachable. The enum offers all three behaviors explicitly.

## Migration

- `ColorMode` is stored as a string (`"Light"` / `"Dark"` / `"System"`) via the same `StringEnumConverter` pattern as the other settings enums.
- Old settings files are migrated on load through a legacy shim (same pattern as `hilightGroupList`): `DarkMode: true` → `Dark`, `DarkMode: false` → `Light` (unchecked meant forced light per the ruling on #698).
- An explicit `ColorMode` key always wins over a leftover `DarkMode` key, regardless of JSON key order; the legacy key is never written back.
- Fresh installs default to `Light`, preserving current behavior bit-for-bit.

## Tests

Six new NUnit tests (`PreferencesColorModeTests`) cover legacy migration in both directions, the default, key-order precedence, and serialization round-trip. Full suite: 1057 passed, 0 failed.

<img width="957" height="599" alt="image" src="https://github.com/user-attachments/assets/c451cff9-0e2a-410f-bc86-8a93983a6168" />
