### PR TITLE
Update WinGet manifests to LogExpert 1.43.0

### DIFF
--- a/tools/winget-sandbox/README.md
+++ b/tools/winget-sandbox/README.md
@@ -42,4 +42,4 @@ winget uninstall --product-code '{9C6E17B8-912C-45F9-9E7F-49CEAD8D6D7A}_is1' --s
 This is a clean installation test, not an upgrade test. Once the first version is
 accepted into `microsoft/winget-pkgs`, also test upgrading from it before relying on
 the release automation in PR #614. Submit only the three YAML files from `winget`
-under `manifests/l/LogExperts/LogExpert/1.40.3/` in the community repository.
+under `manifests/l/LogExperts/LogExpert/1.43.0/` in the community repository.

--- a/winget/LogExperts.LogExpert.installer.yaml
+++ b/winget/LogExperts.LogExpert.installer.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
 
 PackageIdentifier: LogExperts.LogExpert
-PackageVersion: 1.40.3
+PackageVersion: 1.43.0
 InstallerType: inno
 Scope: machine
 ProductCode: '{9C6E17B8-912C-45F9-9E7F-49CEAD8D6D7A}_is1'
@@ -11,8 +11,8 @@ Dependencies:
   - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.10
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/LogExperts/LogExpert/releases/download/v1.40.3/LogExpert-Setup-1.40.3.exe
-  InstallerSha256: f32bde3703da1db0c1a963d37ee0eeab029bb18cbe3b8730ea12eda0eaafe2fa
+  InstallerUrl: https://github.com/LogExperts/LogExpert/releases/download/v1.43.0/LogExpert-Setup-1.43.0.exe
+  InstallerSha256: 7b6decd54626f22ed3ff8b1249222a1c572093a4dca4303b672935d3dcd4de98
 ManifestType: installer
 ManifestVersion: 1.10.0
-ReleaseDate: 2026-06-15
+ReleaseDate: 2026-08-28

--- a/winget/LogExperts.LogExpert.locale.en-US.yaml
+++ b/winget/LogExperts.LogExpert.locale.en-US.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
 
 PackageIdentifier: LogExperts.LogExpert
-PackageVersion: 1.40.3
+PackageVersion: 1.43.0
 PackageLocale: en-US
 Publisher: LogExperts
 PublisherUrl: https://github.com/LogExperts
@@ -17,7 +17,7 @@ Tags:
 - logger-interface
 - logging
 - winforms
-ReleaseNotesUrl: https://github.com/LogExperts/LogExpert/releases/tag/v1.40.3
+ReleaseNotesUrl: https://github.com/LogExperts/LogExpert/releases/tag/v1.43.0
 Documentations:
 - DocumentLabel: Wiki
   DocumentUrl: https://github.com/LogExperts/LogExpert/wiki

--- a/winget/LogExperts.LogExpert.yaml
+++ b/winget/LogExperts.LogExpert.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
 
 PackageIdentifier: LogExperts.LogExpert
-PackageVersion: 1.40.3
+PackageVersion: 1.43.0
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.10.0


### PR DESCRIPTION
Updates all three WinGet manifests to 1.43.0, including the installer URL, SHA256, release date, and release-notes URL. Updates the Sandbox documentation’s submission path.

 Validation:

 - Installer SHA256 verified against the downloaded release.
 - winget validate passed.
 - Windows Sandbox testing passed installation, .NET dependency resolution, version detection, manual application checks, and uninstall.

The unsigned installer still requires SmartScreen approval, so unattended installation remains unresolved.

Related to #385.